### PR TITLE
Correctly stringify tuple subscripts.

### DIFF
--- a/pymbolic/mapper/stringifier.py
+++ b/pymbolic/mapper/stringifier.py
@@ -138,6 +138,8 @@ class StringifyMapper(pymbolic.mapper.Mapper):
         return self.parenthesize_if_needed(
                 self.format("%s[%s]",
                     self.rec(expr.aggregate, PREC_CALL),
+                    self.join_rec(", ", expr.index, PREC_NONE) if
+                    isinstance(expr.index, tuple) else
                     self.rec(expr.index, PREC_NONE)),
                 enclosing_prec, PREC_CALL)
 


### PR DESCRIPTION
Python turns multiple subscripts separated by commas into a tuple of
subscripts. When stringifying this, Pymbolic inserts the set of
parentheses associated with that tuple inside the square brackets for
the subscript. This commit causes Pymbolic to suppress these
parentheses.

That is to say, instead of an output which looks like:

  phi[(a, b)]

we now get:

  phi[a, b]
