### PR TITLE
pass *args and **kwargs through mappers

### DIFF
--- a/pymbolic/mapper/stringifier.py
+++ b/pymbolic/mapper/stringifier.py
@@ -89,9 +89,9 @@ class StringifyMapper(pymbolic.mapper.Mapper):
     def join(self, joiner, iterable):
         return self.format(joiner.join("%s" for i in iterable), *iterable)
 
-    def join_rec(self, joiner, iterable, prec):
+    def join_rec(self, joiner, iterable, prec, *args, **kwargs):
         f = joiner.join("%s" for i in iterable)
-        return self.format(f, *[self.rec(i, prec) for i in iterable])
+        return self.format(f, *[self.rec(i, prec, *args, **kwargs) for i in iterable])
 
     def parenthesize(self, s):
         return "(%s)" % s
@@ -106,14 +106,14 @@ class StringifyMapper(pymbolic.mapper.Mapper):
 
     # {{{ mappings
 
-    def handle_unsupported_expression(self, victim, enclosing_prec):
+    def handle_unsupported_expression(self, victim, enclosing_prec, *args, **kwargs):
         strifier = victim.stringifier()
         if isinstance(self, strifier):
             raise ValueError("stringifier '%s' can't handle '%s'"
                     % (self, victim.__class__))
-        return strifier(self.constant_mapper)(victim, enclosing_prec)
+        return strifier(self.constant_mapper)(victim, enclosing_prec, *args, **kwargs)
 
-    def map_constant(self, expr, enclosing_prec):
+    def map_constant(self, expr, enclosing_prec, *args, **kwargs):
         result = self.constant_mapper(expr)
 
         if not (result.startswith("(") and result.endswith(")")) \
@@ -123,72 +123,73 @@ class StringifyMapper(pymbolic.mapper.Mapper):
         else:
             return result
 
-    def map_variable(self, expr, enclosing_prec):
+    def map_variable(self, expr, enclosing_prec, *args, **kwargs):
         return expr.name
 
-    def map_function_symbol(self, expr, enclosing_prec):
+    def map_function_symbol(self, expr, enclosing_prec, *args, **kwargs):
         return expr.__class__.__name__
 
-    def map_call(self, expr, enclosing_prec):
+    def map_call(self, expr, enclosing_prec, *args, **kwargs):
         return self.format("%s(%s)",
-                self.rec(expr.function, PREC_CALL),
-                self.join_rec(", ", expr.parameters, PREC_NONE))
+                self.rec(expr.function, PREC_CALL, *args, **kwargs),
+                self.join_rec(", ", expr.parameters, PREC_NONE, *args, **kwargs))
 
-    def map_call_with_kwargs(self, expr, enclosing_prec):
+    def map_call_with_kwargs(self, expr, enclosing_prec, *args, **kwargs):
         args_strings = (
-                tuple(self.rec(ch, PREC_NONE) for ch in expr.parameters)
+                tuple(self.rec(ch, PREC_NONE, *args, **kwargs)
+                      for ch in expr.parameters)
                 +
-                tuple("%s=%s" % (name, self.rec(ch, PREC_NONE))
+                tuple("%s=%s" % (name, self.rec(ch, PREC_NONE, *args, **kwargs))
                     for name, ch in expr.kw_parameters.items()))
         return self.format("%s(%s)",
-                self.rec(expr.function, PREC_CALL),
+                self.rec(expr.function, PREC_CALL, *args, **kwargs),
                 ", ".join(args_strings))
 
-    def map_subscript(self, expr, enclosing_prec):
+    def map_subscript(self, expr, enclosing_prec, *args, **kwargs):
         if isinstance(expr.index, tuple):
-            index_str = self.join_rec(", ", expr.index, PREC_NONE)
+            index_str = self.join_rec(", ", expr.index, PREC_NONE, *args, **kwargs)
         else:
-            index_str = self.rec(expr.index, PREC_NONE)
+            index_str = self.rec(expr.index, PREC_NONE, *args, **kwargs)
 
         return self.parenthesize_if_needed(
                 self.format("%s[%s]",
-                    self.rec(expr.aggregate, PREC_CALL),
+                    self.rec(expr.aggregate, PREC_CALL, *args, **kwargs),
                     index_str),
                 enclosing_prec, PREC_CALL)
 
-    def map_lookup(self, expr, enclosing_prec):
+    def map_lookup(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
                 self.format("%s.%s",
-                    self.rec(expr.aggregate, PREC_CALL),
+                    self.rec(expr.aggregate, PREC_CALL, *args, **kwargs),
                     expr.name),
                 enclosing_prec, PREC_CALL)
 
-    def map_sum(self, expr, enclosing_prec):
+    def map_sum(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec(" + ", expr.children, PREC_SUM),
+                self.join_rec(" + ", expr.children, PREC_SUM, *args, **kwargs),
                 enclosing_prec, PREC_SUM)
 
-    def map_product(self, expr, enclosing_prec):
+    def map_product(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec("*", expr.children, PREC_PRODUCT),
+                self.join_rec("*", expr.children, PREC_PRODUCT, *args, **kwargs),
                 enclosing_prec, PREC_PRODUCT)
 
-    def map_quotient(self, expr, enclosing_prec):
+    def map_quotient(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
                 self.format("%s / %s",
                     # space is necessary--otherwise '/*' becomes
                     # start-of-comment in C. ('*' from dereference)
-                    self.rec(expr.numerator, PREC_PRODUCT),
-                    self.rec(expr.denominator, PREC_POWER)),  # analogous to ^{-1}
+                    self.rec(expr.numerator, PREC_PRODUCT, *args, **kwargs),
+                    self.rec(expr.denominator, PREC_POWER, *args, **kwargs)),  # analogous to ^{-1}
                 enclosing_prec, PREC_PRODUCT)
 
-    def map_floor_div(self, expr, enclosing_prec):
+    def map_floor_div(self, expr, enclosing_prec, *args, **kwargs):
         # (-1) * ((-1)*x // 5) should not reassociate. Therefore raise precedence
         # on the numerator and shield against surrounding products.
 
         result = self.format("%s // %s",
-                    self.rec(expr.numerator, PREC_POWER),
-                    self.rec(expr.denominator, PREC_POWER))  # analogous to ^{-1}
+                    self.rec(expr.numerator, PREC_POWER, *args, **kwargs),
+                    self.rec(expr.denominator, PREC_POWER, *args, **kwargs))  # analogous to ^{-1}
 
         # Note ">=", not ">" as in parenthesize_if_needed().
         if enclosing_prec >= PREC_PRODUCT:
@@ -196,101 +197,101 @@ class StringifyMapper(pymbolic.mapper.Mapper):
         else:
             return result
 
-    def map_power(self, expr, enclosing_prec):
+    def map_power(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
                 self.format("%s**%s",
-                    self.rec(expr.base, PREC_POWER),
-                    self.rec(expr.exponent, PREC_POWER)),
+                    self.rec(expr.base, PREC_POWER, *args, **kwargs),
+                    self.rec(expr.exponent, PREC_POWER, *args, **kwargs)),
                 enclosing_prec, PREC_POWER)
 
-    def map_remainder(self, expr, enclosing_prec):
+    def map_remainder(self, expr, enclosing_prec, *args, **kwargs):
         return self.format("(%s %% %s)",
-                    self.rec(expr.numerator, PREC_PRODUCT),
-                    self.rec(expr.denominator, PREC_POWER))  # analogous to ^{-1}
+                    self.rec(expr.numerator, PREC_PRODUCT, *args, **kwargs),
+                    self.rec(expr.denominator, PREC_POWER, *args, **kwargs))  # analogous to ^{-1}
 
-    def map_polynomial(self, expr, enclosing_prec):
+    def map_polynomial(self, expr, enclosing_prec, *args, **kwargs):
         from pymbolic.primitives import flattened_sum
         return self.rec(flattened_sum(
             [coeff*expr.base**exp for exp, coeff in expr.data[::-1]]),
-            enclosing_prec)
+            enclosing_prec, *args, **kwargs)
 
-    def map_left_shift(self, expr, enclosing_prec):
+    def map_left_shift(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
                 self.format("%s << %s",
-                    self.rec(expr.shiftee, PREC_SHIFT),
-                    self.rec(expr.shift, PREC_SHIFT)),
+                    self.rec(expr.shiftee, PREC_SHIFT, *args, **kwargs),
+                    self.rec(expr.shift, PREC_SHIFT, *args, **kwargs)),
                 enclosing_prec, PREC_SHIFT)
 
-    def map_right_shift(self, expr, enclosing_prec):
+    def map_right_shift(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
                 self.format("%s >> %s",
-                    self.rec(expr.shiftee, PREC_SHIFT),
-                    self.rec(expr.shift, PREC_SHIFT)),
+                    self.rec(expr.shiftee, PREC_SHIFT, *args, **kwargs),
+                    self.rec(expr.shift, PREC_SHIFT, *args, **kwargs)),
                 enclosing_prec, PREC_SHIFT)
 
-    def map_bitwise_not(self, expr, enclosing_prec):
+    def map_bitwise_not(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                "~" + self.rec(expr.child, PREC_UNARY),
+                "~" + self.rec(expr.child, PREC_UNARY, *args, **kwargs),
                 enclosing_prec, PREC_UNARY)
 
-    def map_bitwise_or(self, expr, enclosing_prec):
+    def map_bitwise_or(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec(" | ", expr.children, PREC_BITWISE_OR),
+                self.join_rec(" | ", expr.children, PREC_BITWISE_OR, *args, **kwargs),
                 enclosing_prec, PREC_BITWISE_OR)
 
-    def map_bitwise_xor(self, expr, enclosing_prec):
+    def map_bitwise_xor(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec(" ^ ", expr.children, PREC_BITWISE_XOR),
+                self.join_rec(" ^ ", expr.children, PREC_BITWISE_XOR, *args, **kwargs),
                 enclosing_prec, PREC_BITWISE_XOR)
 
-    def map_bitwise_and(self, expr, enclosing_prec):
+    def map_bitwise_and(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec(" ^ ", expr.children, PREC_BITWISE_AND),
+                self.join_rec(" ^ ", expr.children, PREC_BITWISE_AND, *args, **kwargs),
                 enclosing_prec, PREC_BITWISE_AND)
 
-    def map_comparison(self, expr, enclosing_prec):
+    def map_comparison(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
                 self.format("%s %s %s",
-                    self.rec(expr.left, PREC_COMPARISON),
+                    self.rec(expr.left, PREC_COMPARISON, *args, **kwargs),
                     expr.operator,
-                    self.rec(expr.right, PREC_COMPARISON)),
+                    self.rec(expr.right, PREC_COMPARISON, *args, **kwargs)),
                 enclosing_prec, PREC_COMPARISON)
 
-    def map_logical_not(self, expr, enclosing_prec):
+    def map_logical_not(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                "not " + self.rec(expr.child, PREC_UNARY),
+                "not " + self.rec(expr.child, PREC_UNARY, *args, **kwargs),
                 enclosing_prec, PREC_UNARY)
 
-    def map_logical_or(self, expr, enclosing_prec):
+    def map_logical_or(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec(" or ", expr.children, PREC_LOGICAL_OR),
+                self.join_rec(" or ", expr.children, PREC_LOGICAL_OR, *args, **kwargs),
                 enclosing_prec, PREC_LOGICAL_OR)
 
-    def map_logical_and(self, expr, enclosing_prec):
+    def map_logical_and(self, expr, enclosing_prec, *args, **kwargs):
         return self.parenthesize_if_needed(
-                self.join_rec(" and ", expr.children, PREC_LOGICAL_AND),
+                self.join_rec(" and ", expr.children, PREC_LOGICAL_AND, *args, **kwargs),
                 enclosing_prec, PREC_LOGICAL_AND)
 
-    def map_list(self, expr, enclosing_prec):
-        return self.format("[%s]", self.join_rec(", ", expr, PREC_NONE))
+    def map_list(self, expr, enclosing_prec, *args, **kwargs):
+        return self.format("[%s]", self.join_rec(", ", expr, PREC_NONE, *args, **kwargs))
 
     map_vector = map_list
 
-    def map_tuple(self, expr, enclosing_prec):
-        el_str = ", ".join(self.rec(child, PREC_NONE) for child in expr)
+    def map_tuple(self, expr, enclosing_prec, *args, **kwargs):
+        el_str = ", ".join(self.rec(child, PREC_NONE, *args, **kwargs) for child in expr)
         if len(expr) == 1:
             el_str += ","
 
         return "(%s)" % el_str
 
-    def map_numpy_array(self, expr, enclosing_prec):
+    def map_numpy_array(self, expr, enclosing_prec, *args, **kwargs):
         import numpy
 
         from pytools import indices_in_shape
         str_array = numpy.zeros(expr.shape, dtype="object")
         max_length = 0
         for i in indices_in_shape(expr.shape):
-            s = self.rec(expr[i], PREC_NONE)
+            s = self.rec(expr[i], PREC_NONE, *args, **kwargs)
             max_length = max(len(s), max_length)
             str_array[i] = s.replace("\n", "\n  ")
 
@@ -306,10 +307,10 @@ class StringifyMapper(pymbolic.mapper.Mapper):
             else:
                 return "array(\n%s)" % "".join(lines)
 
-    def map_multivector(self, expr, enclosing_prec):
-        return expr.stringify(self.rec, enclosing_prec)
+    def map_multivector(self, expr, enclosing_prec, *args, **kwargs):
+        return expr.stringify(self.rec, enclosing_prec, *args, **kwargs)
 
-    def map_common_subexpression(self, expr, enclosing_prec):
+    def map_common_subexpression(self, expr, enclosing_prec, *args, **kwargs):
         from pymbolic.primitives import CommonSubexpression
         if type(expr) is CommonSubexpression:
             type_name = "CSE"
@@ -317,49 +318,49 @@ class StringifyMapper(pymbolic.mapper.Mapper):
             type_name = type(expr).__name__
 
         return self.format("%s(%s)",
-                type_name, self.rec(expr.child, PREC_NONE))
+                type_name, self.rec(expr.child, PREC_NONE, *args, **kwargs))
 
-    def map_if(self, expr, enclosing_prec):
+    def map_if(self, expr, enclosing_prec, *args, **kwargs):
         return "If(%s, %s, %s)" % (
-                self.rec(expr.condition, PREC_NONE),
-                self.rec(expr.then, PREC_NONE),
-                self.rec(expr.else_, PREC_NONE))
+                self.rec(expr.condition, PREC_NONE, *args, **kwargs),
+                self.rec(expr.then, PREC_NONE, *args, **kwargs),
+                self.rec(expr.else_, PREC_NONE, *args, **kwargs))
 
-    def map_if_positive(self, expr, enclosing_prec):
+    def map_if_positive(self, expr, enclosing_prec, *args, **kwargs):
         return "If(%s > 0, %s, %s)" % (
-                self.rec(expr.criterion, PREC_NONE),
-                self.rec(expr.then, PREC_NONE),
-                self.rec(expr.else_, PREC_NONE))
+                self.rec(expr.criterion, PREC_NONE, *args, **kwargs),
+                self.rec(expr.then, PREC_NONE, *args, **kwargs),
+                self.rec(expr.else_, PREC_NONE, *args, **kwargs))
 
-    def map_min(self, expr, enclosing_prec):
+    def map_min(self, expr, enclosing_prec, *args, **kwargs):
         what = type(expr).__name__.lower()
         return self.format("%s(%s)",
-                what, self.join_rec(", ", expr.children, PREC_NONE))
+                what, self.join_rec(", ", expr.children, PREC_NONE, *args, **kwargs))
 
     map_max = map_min
 
-    def map_derivative(self, expr, enclosing_prec):
+    def map_derivative(self, expr, enclosing_prec, *args, **kwargs):
         derivs = " ".join(
                 "d/d%s" % v
                 for v in expr.variables)
 
         return "%s %s" % (
-                derivs, self.rec(expr.child, PREC_PRODUCT))
+                derivs, self.rec(expr.child, PREC_PRODUCT, *args, **kwargs))
 
-    def map_substitution(self, expr, enclosing_prec):
+    def map_substitution(self, expr, enclosing_prec, *args, **kwargs):
         substs = ", ".join(
-                "%s=%s" % (name, self.rec(val, PREC_NONE))
+                "%s=%s" % (name, self.rec(val, PREC_NONE, *args, **kwargs))
                 for name, val in zip(expr.variables, expr.values))
 
-        return "[%s]{%s}" % (self.rec(expr.child, PREC_NONE), substs)
+        return "[%s]{%s}" % (self.rec(expr.child, PREC_NONE, *args, **kwargs), substs)
 
-    def map_slice(self, expr, enclosing_prec):
+    def map_slice(self, expr, enclosing_prec, *args, **kwargs):
         children = []
         for child in expr.children:
             if child is None:
                 children.append("")
             else:
-                children.append(self.rec(child, PREC_NONE))
+                children.append(self.rec(child, PREC_NONE, *args, **kwargs))
 
         return self.parenthesize_if_needed(
                 self.join(":", children),
@@ -367,13 +368,13 @@ class StringifyMapper(pymbolic.mapper.Mapper):
 
     # }}}
 
-    def __call__(self, expr, prec=PREC_NONE):
+    def __call__(self, expr, prec=PREC_NONE, *args, **kwargs):
         """Return a string corresponding to *expr*. If the enclosing
         precedence level *prec* is higher than *prec* (see :ref:`prec-constants`),
         parenthesize the result.
         """
 
-        return pymbolic.mapper.Mapper.__call__(self, expr, prec)
+        return pymbolic.mapper.Mapper.__call__(self, expr, prec, *args, **kwargs)
 
 # }}}
 
@@ -404,7 +405,7 @@ class CSESplittingStringifyMapperMixin(object):
     See :class:`pymbolic.mapper.c_code.CCodeMapper` for an example
     of the use of this mix-in.
     """
-    def map_common_subexpression(self, expr, enclosing_prec):
+    def map_common_subexpression(self, expr, enclosing_prec, *args, **kwargs):
         try:
             self.cse_to_name
         except AttributeError:
@@ -415,7 +416,7 @@ class CSESplittingStringifyMapperMixin(object):
         try:
             cse_name = self.cse_to_name[expr.child]
         except KeyError:
-            str_child = self.rec(expr.child, PREC_NONE)
+            str_child = self.rec(expr.child, PREC_NONE, *args, **kwargs)
 
             if expr.prefix is not None:
                 def generate_cse_names():
@@ -456,15 +457,15 @@ class SortingStringifyMapper(StringifyMapper):
         StringifyMapper.__init__(self, constant_mapper)
         self.reverse = reverse
 
-    def map_sum(self, expr, enclosing_prec):
-        entries = [self.rec(i, PREC_SUM) for i in expr.children]
+    def map_sum(self, expr, enclosing_prec, *args, **kwargs):
+        entries = [self.rec(i, PREC_SUM, *args, **kwargs) for i in expr.children]
         entries.sort(reverse=self.reverse)
         return self.parenthesize_if_needed(
                 self.join(" + ", entries),
                 enclosing_prec, PREC_SUM)
 
-    def map_product(self, expr, enclosing_prec):
-        entries = [self.rec(i, PREC_PRODUCT) for i in expr.children]
+    def map_product(self, expr, enclosing_prec, *args, **kwargs):
+        entries = [self.rec(i, PREC_PRODUCT, *args, **kwargs) for i in expr.children]
         entries.sort(reverse=self.reverse)
         return self.parenthesize_if_needed(
                 self.join("*", entries),
@@ -480,7 +481,7 @@ class SimplifyingSortingStringifyMapper(StringifyMapper):
         StringifyMapper.__init__(self, constant_mapper)
         self.reverse = reverse
 
-    def map_sum(self, expr, enclosing_prec):
+    def map_sum(self, expr, enclosing_prec, *args, **kwargs):
         def get_neg_product(expr):
             from pymbolic.primitives import is_zero, Product
 
@@ -500,9 +501,9 @@ class SimplifyingSortingStringifyMapper(StringifyMapper):
         for ch in expr.children:
             neg_prod = get_neg_product(ch)
             if neg_prod is not None:
-                negatives.append(self.rec(neg_prod, PREC_PRODUCT))
+                negatives.append(self.rec(neg_prod, PREC_PRODUCT, *args, **kwargs))
             else:
-                positives.append(self.rec(ch, PREC_SUM))
+                positives.append(self.rec(ch, PREC_SUM, *args, **kwargs))
 
         positives.sort(reverse=self.reverse)
         positives = " + ".join(positives)
@@ -514,7 +515,7 @@ class SimplifyingSortingStringifyMapper(StringifyMapper):
 
         return self.parenthesize_if_needed(result, enclosing_prec, PREC_SUM)
 
-    def map_product(self, expr, enclosing_prec):
+    def map_product(self, expr, enclosing_prec, *args, **kwargs):
         entries = []
         i = 0
         from pymbolic.primitives import is_zero
@@ -526,10 +527,10 @@ class SimplifyingSortingStringifyMapper(StringifyMapper):
                 # Otherwise two unary minus signs merge into a pre-decrement.
                 entries.append(
                         self.format(
-                            "- %s", self.rec(expr.children[i+1], PREC_UNARY)))
+                            "- %s", self.rec(expr.children[i+1], PREC_UNARY, *args, **kwargs)))
                 i += 2
             else:
-                entries.append(self.rec(child, PREC_PRODUCT))
+                entries.append(self.rec(child, PREC_PRODUCT, *args, **kwargs))
                 i += 1
 
         entries.sort(reverse=self.reverse)


### PR DESCRIPTION
Cause mappers to pass through additional arguments more consistently. This facilitates the subclassing of mappers. For example, one can implement a subclass of stringify which automatically indents code. This requires the current indentation level to be passed through the mapper.
