### PR TITLE
Make CompiledExpression + pickling work on both Python 2 and Python 3.

### DIFF
--- a/test/test_pymbolic.py
+++ b/test/test_pymbolic.py
@@ -431,6 +431,17 @@ def test_ast_interop():
             print(lhs, rhs)
 
 
+def test_compile():
+    from pymbolic import parse, compile
+    code = compile(parse("x ** y"), ["x", "y"])
+    assert code(2, 5) == 32
+
+    # Test pickling of compiled code.
+    import pickle
+    code = pickle.loads(pickle.dumps(code))
+    assert code(3, 3) == 27
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
Changed to use `__getstate__()` and `__setstate__()` rather than
`__getinitargs__()`, which is Py2 only.