### PR TITLE
Fix avoidable exponential blowup in unifier.

### DIFF
--- a/test/test_pymbolic.py
+++ b/test/test_pymbolic.py
@@ -467,6 +467,11 @@ def test_unifier():
     assert match_found(recs, set([(b, e), (a, d+f)]))
     assert match_found(recs, set([(b, f), (a, d+e)]))
 
+    vals = [var("v" + str(i)) for i in range(100)]
+    recs = UnidirectionalUnifier("a")(sum(vals[1:]) + a, sum(vals))
+    assert len(recs) == 1
+    assert match_found(recs, set([(a, var("v0"))]))
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Change the code to do what the previous code tried to do, which is to
match free variables only after matching the more complex terms. This
avoids iterating over all possible subsets of the RHS.