### PR TITLE
Do not splat shape arg to np.ndindex(): breaks using integers as shapes

### DIFF
--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -458,7 +458,7 @@ class IdentityMapper(Mapper):
     def map_numpy_array(self, expr, *args, **kwargs):
         import numpy
         result = numpy.empty(expr.shape, dtype=object)
-        for i in numpy.ndindex(*expr.shape):
+        for i in numpy.ndindex(expr.shape):
             result[i] = self.rec(expr[i], *args, **kwargs)
         return result
 
@@ -648,7 +648,7 @@ class WalkMapper(RecursiveMapper):
             return
 
         import numpy
-        for i in numpy.ndindex(*expr.shape):
+        for i in numpy.ndindex(expr.shape):
             self.rec(expr[i], *args, **kwargs)
 
         self.post_visit(expr, *args, **kwargs)

--- a/pymbolic/mapper/differentiator.py
+++ b/pymbolic/mapper/differentiator.py
@@ -213,7 +213,7 @@ class DifferentiationMapper(pymbolic.mapper.RecursiveMapper):
     def map_numpy_array(self, expr, *args):
         import numpy
         result = numpy.empty(expr.shape, dtype=object)
-        for i in numpy.ndindex(*result.shape):
+        for i in numpy.ndindex(result.shape):
             result[i] = self.rec(expr[i], *args)
         return result
 

--- a/pymbolic/mapper/evaluator.py
+++ b/pymbolic/mapper/evaluator.py
@@ -157,7 +157,7 @@ class EvaluationMapper(RecursiveMapper, CSECachingMapperMixin):
     def map_numpy_array(self, expr):
         import numpy
         result = numpy.empty(expr.shape, dtype=object)
-        for i in numpy.ndindex(*expr.shape):
+        for i in numpy.ndindex(expr.shape):
             result[i] = self.rec(expr[i])
         return result
 

--- a/pymbolic/mapper/stringifier.py
+++ b/pymbolic/mapper/stringifier.py
@@ -345,7 +345,7 @@ class StringifyMapper(pymbolic.mapper.Mapper):
 
         str_array = numpy.zeros(expr.shape, dtype="object")
         max_length = 0
-        for i in numpy.ndindex(*expr.shape):
+        for i in numpy.ndindex(expr.shape):
             s = self.rec(expr[i], PREC_NONE, *args, **kwargs)
             max_length = max(len(s), max_length)
             str_array[i] = s.replace("\n", "\n  ")

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -1699,7 +1699,7 @@ def make_common_subexpression(field, prefix=None, scope=None):
 
     elif have_obj_array and logical_shape != ():
         result = numpy.zeros(logical_shape, dtype=object)
-        for i in numpy.ndindex(*logical_shape):
+        for i in numpy.ndindex(logical_shape):
             if prefix is not None:
                 component_prefix = prefix+"_".join(str(i_i) for i_i in i)
             else:
@@ -1752,7 +1752,7 @@ def make_sym_array(name, shape, var_factory=Variable):
 
     import numpy as np
     result = np.zeros(shape, dtype=object)
-    for i in np.ndindex(*shape):
+    for i in np.ndindex(shape):
         result[i] = vfld.index(i)
 
     return result


### PR DESCRIPTION
As far as I can tell, `np.ndindex(*shape)` is an antipattern, because it breaks when `shape` is just an integer. (The splat expects an iterable.)

FYI @mattwala 