### PR TITLE
Added `__invert__` in `Expression`

### DIFF
--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -381,6 +381,7 @@ class Expression(object):
 
     def __inv__(self):
         return BitwiseNot(self)
+    __invert__ = __inv__
 
     def __or__(self, other):
         return BitwiseOr((self, other))

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -379,9 +379,8 @@ class Expression(object):
 
     # {{{ bitwise operators
 
-    def __inv__(self):
+    def __invert__(self):
         return BitwiseNot(self)
-    __invert__ = __inv__
 
     def __or__(self, other):
         return BitwiseOr((self, other))


### PR DESCRIPTION
Just a minor edit for overriding (~) in `Expression` with the method name `__invert__` for later Python versions.