### PR TITLE
Make np bool a valid constant class

### DIFF
--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -1599,7 +1599,7 @@ VALID_OPERANDS = (Expression,)
 
 try:
     import numpy
-    VALID_CONSTANT_CLASSES += (numpy.number,)
+    VALID_CONSTANT_CLASSES += (numpy.number, numpy.bool_)
 except ImportError:
     pass
 

--- a/test/test_pymbolic.py
+++ b/test/test_pymbolic.py
@@ -657,6 +657,13 @@ def test_differentiator_flags_for_nonsmooth_and_discontinuous():
     assert result == 0
 
 
+def test_np_bool_handling():
+    from pymbolic.mapper.evaluator import evaluate
+    numpy = pytest.importorskip("numpy")
+    expr = prim.LogicalNot(numpy.bool_(False))
+    assert evaluate(expr) is True
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
Per <https://numpy.org/doc/stable/_images/dtype-hierarchy.png>, np.bool_ does not come under np.number, which is why the included test fails on `main`.