### PR TITLE
Raise error if `None` is passed to `is_nonzero`

### DIFF
--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -1627,6 +1627,9 @@ def unregister_constant_class(class_):
 
 
 def is_nonzero(value):
+    if value is None:
+        raise ValueError("is_nonzero is undefined for None")
+
     try:
         return bool(value)
     except ValueError:


### PR DESCRIPTION
Simple patch for the `is_nonzero` function that properly handles `None` values