### PR TITLE
Improve exception message in Comparison

### DIFF
--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -1167,7 +1167,7 @@ class Comparison(Expression):
         operator = self.name_to_operator.get(operator, operator)
 
         if operator not in self.operator_to_name:
-            raise RuntimeError("invalid operator")
+            raise RuntimeError(f"invalid operator: '{operator}'")
         self.operator = operator
 
     def __getinitargs__(self):


### PR DESCRIPTION
Managed to write `Comparison("<", x, y)` and was confused what it didn't like :(