### PR TITLE
Optimizations for DerivativeBinder

### DIFF
--- a/pymbolic/cse.py
+++ b/pymbolic/cse.py
@@ -122,7 +122,7 @@ class CSEMapper(IdentityMapper):
         return type(expr)(
                 expr.child,
                 expr.variables,
-                tuple(self.rec(v) for v in expr.values))
+                tuple([self.rec(v) for v in expr.values]))
 
 
 def tag_common_subexpressions(exprs):

--- a/pymbolic/geometric_algebra/mapper.py
+++ b/pymbolic/geometric_algebra/mapper.py
@@ -301,10 +301,12 @@ class DerivativeBinder(IdentityMapper):
             result = new_result
 
         from pymbolic.primitives import flattened_sum
-        return flattened_sum(
-                    type(expr)(tuple(
-                        self.rec(prod_term) for prod_term in prod_term_list))
-                    for prod_term_list in result)
+        return flattened_sum([
+                    type(expr)(tuple([
+                        self.rec(prod_term) for prod_term in prod_term_list
+                        ]))
+                    for prod_term_list in result
+                    ])
 
     map_bitwise_xor = map_product
     map_bitwise_or = map_product
@@ -328,12 +330,13 @@ class DerivativeBinder(IdentityMapper):
         assert n_axes
 
         from pymbolic.primitives import flattened_sum
-        return flattened_sum(
+        return flattened_sum([
                 self.take_derivative(
                     axis,
                     self.nabla_component_to_unit_vector(expr.nabla_id, axis)
                     (rec_operand))
-                for axis in range(n_axes))
+                for axis in range(n_axes)
+                ])
 
 # }}}
 

--- a/pymbolic/geometric_algebra/mapper.py
+++ b/pymbolic/geometric_algebra/mapper.py
@@ -270,6 +270,11 @@ class DerivativeBinder(IdentityMapper):
                 nabla_finder.setdefault(
                         ncomp.nabla_id, set()).add((child_idx, ncomp.ambient_axis))
 
+        if nabla_finder and not any(d_source_nabla_ids_per_child):
+            raise ValueError(f"no derivative source found to resolve in '{expr}'"
+                    " -- did you forget to wrap the term that should have its "
+                    "derivative taken in 'Derivative()(term)'?")
+
         if not has_d_source_nablas:
             rec_children = [self.rec(child) for child in expr.children]
             if all(rec_child is child
@@ -279,11 +284,6 @@ class DerivativeBinder(IdentityMapper):
             return type(expr)(tuple(rec_children))
 
         # }}}
-
-        if nabla_finder and not any(d_source_nabla_ids_per_child):
-            raise ValueError(f"no derivative source found to resolve in '{expr}'"
-                    " -- did you forget to wrap the term that should have its "
-                    "derivative taken in 'Derivative()(term)'?")
 
         # a list of lists, the outer level presenting a sum, the inner a product
         result = [list(expr.children)]

--- a/pymbolic/geometric_algebra/mapper.py
+++ b/pymbolic/geometric_algebra/mapper.py
@@ -53,7 +53,11 @@ class IdentityMapper(IdentityMapperBase):
     map_nabla_component = map_multivector_variable
 
     def map_derivative_source(self, expr):
-        return type(expr)(self.rec(expr.operand), expr.nabla_id)
+        operand = self.rec(expr.operand)
+        if operand is expr.operand:
+            return expr
+
+        return type(expr)(operand, expr.nabla_id)
 
 
 class CombineMapper(CombineMapperBase):
@@ -92,7 +96,11 @@ class EvaluationMapper(EvaluationMapperBase):
     map_nabla = map_nabla_component
 
     def map_derivative_source(self, expr):
-        return type(expr)(self.rec(expr.operand), expr.nabla_id)
+        operand = self.rec(expr.operand)
+        if operand is expr.operand:
+            return expr
+
+        return type(expr)(operand, expr.nabla_id)
 
 
 class StringifyMapper(StringifyMapperBase):

--- a/pymbolic/interop/ast.py
+++ b/pymbolic/interop/ast.py
@@ -188,7 +188,7 @@ class ASTToPymbolic(ASTMapper):
     def map_Call(self, expr):  # noqa
         # (expr func, expr* args, keyword* keywords)
         func = self.rec(expr.func)
-        args = tuple(self.rec(arg) for arg in expr.args)
+        args = tuple([self.rec(arg) for arg in expr.args])
         if expr.keywords:
             return p.CallWithKwargs(func, args,
                     {
@@ -248,7 +248,7 @@ class ASTToPymbolic(ASTMapper):
 
     def map_Tuple(self, expr):  # noqa
         # (expr* elts, expr_context ctx)
-        return tuple(self.rec(ti) for ti in expr.elts)
+        return tuple([self.rec(ti) for ti in expr.elts])
 
 # }}}
 

--- a/pymbolic/interop/common.py
+++ b/pymbolic/interop/common.py
@@ -87,10 +87,10 @@ class SympyLikeToPymbolicMapper(SympyLikeMapperBase):
         return int(expr)
 
     def map_Add(self, expr):  # noqa
-        return prim.Sum(tuple(self.rec(arg) for arg in expr.args))
+        return prim.Sum(tuple([self.rec(arg) for arg in expr.args]))
 
     def map_Mul(self, expr):  # noqa
-        return prim.Product(tuple(self.rec(arg) for arg in expr.args))
+        return prim.Product(tuple([self.rec(arg) for arg in expr.args]))
 
     def map_Pow(self, expr):  # noqa
         base, exp = expr.args
@@ -98,13 +98,13 @@ class SympyLikeToPymbolicMapper(SympyLikeMapperBase):
 
     def map_Subs(self, expr):  # noqa
         return prim.Substitution(self.rec(expr.expr),
-                tuple(v.name for v in expr.variables),
-                tuple(self.rec(v) for v in expr.point),
+                tuple([v.name for v in expr.variables]),
+                tuple([self.rec(v) for v in expr.point]),
                 )
 
     def map_Derivative(self, expr):  # noqa
         return prim.Derivative(self.rec(expr.expr),
-                tuple(v.name for v in expr.variables))
+                tuple([v.name for v in expr.variables]))
 
     def map_UnevaluatedExpr(self, expr):  # noqa
         return self.rec(expr.args[0])
@@ -120,7 +120,7 @@ class SympyLikeToPymbolicMapper(SympyLikeMapperBase):
                 else:
                     return prim.Subscript(args[0], tuple(args[1:]))
             return prim.Variable(self.function_name(expr))(
-                    *tuple(self.rec(arg) for arg in expr.args))
+                    *[self.rec(arg) for arg in expr.args])
         else:
             return SympyLikeMapperBase.not_supported(self, expr)
 
@@ -176,8 +176,8 @@ class PymbolicToSympyLikeMapper(EvaluationMapper):
 
     def map_substitution(self, expr):
         return self.sym.Subs(self.rec(expr.child),
-                tuple(self.sym.Symbol(v) for v in expr.variables),
-                tuple(self.rec(v) for v in expr.values),
+                tuple([self.sym.Symbol(v) for v in expr.variables]),
+                tuple([self.rec(v) for v in expr.values]),
                 )
 
     def map_if(self, expr):

--- a/pymbolic/interop/sympy.py
+++ b/pymbolic/interop/sympy.py
@@ -69,7 +69,7 @@ class SympyToPymbolicMapper(SympyLikeToPymbolicMapper):
 
         return prim.Subscript(
             self.rec(expr.args[0].args[0]),
-            tuple(self.rec(i) for i in expr.args[1:])
+            tuple([self.rec(i) for i in expr.args[1:]])
             )
 
     def map_CSE(self, expr):  # noqa
@@ -103,7 +103,7 @@ class PymbolicToSympyMapper(PymbolicToSympyLikeMapper):
     def map_subscript(self, expr):
         return self.sym.Indexed(
             self.sym.IndexedBase(self.rec(expr.aggregate)),
-            *tuple(self.rec(i) for i in expr.index_tuple)
+            *[self.rec(i) for i in expr.index_tuple]
             )
 # }}}
 

--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -180,12 +180,12 @@ class Mapper:
 
         if isinstance(expr, primitives.VALID_CONSTANT_CLASSES):
             return self.map_constant(expr, *args, **kwargs)
+        elif is_numpy_array(expr):
+            return self.map_numpy_array(expr, *args, **kwargs)
         elif isinstance(expr, list):
             return self.map_list(expr, *args, **kwargs)
         elif isinstance(expr, tuple):
             return self.map_tuple(expr, *args, **kwargs)
-        elif is_numpy_array(expr):
-            return self.map_numpy_array(expr, *args, **kwargs)
         else:
             raise ValueError(
                     "{} encountered invalid foreign object: {}".format(

--- a/pymbolic/mapper/collector.py
+++ b/pymbolic/mapper/collector.py
@@ -103,8 +103,9 @@ class TermCollector(IdentityMapper):
             term2coeff[term] = term2coeff.get(term, 0) + coeff
 
         def rep2term(rep):
-            return pymbolic.flattened_product(base**exp for base, exp in rep)
+            return pymbolic.flattened_product([base**exp for base, exp in rep])
 
-        result = pymbolic.flattened_sum(coeff*rep2term(termrep)
-                for termrep, coeff in term2coeff.items())
+        result = pymbolic.flattened_sum([
+            coeff*rep2term(termrep) for termrep, coeff in term2coeff.items()
+            ])
         return result

--- a/pymbolic/mapper/distributor.py
+++ b/pymbolic/mapper/distributor.py
@@ -84,10 +84,10 @@ class DistributeMapper(IdentityMapper):
                 else:
                     rest = 1
 
-                result = self.collect(pymbolic.flattened_sum(
+                result = self.collect(pymbolic.flattened_sum([
                        pymbolic.flattened_product(leading) * dist(sumchild*rest)
                        for sumchild in sum.children
-                       ))
+                       ]))
                 return result
 
         return dist(IdentityMapper.map_product(self, expr))
@@ -99,15 +99,17 @@ class DistributeMapper(IdentityMapper):
             # not the smartest thing we can do, but at least *something*
             return pymbolic.flattened_product([
                     type(expr)(1, self.rec(expr.denominator)),
-                    self.rec(expr.numerator)])
+                    self.rec(expr.numerator)
+                    ])
 
     def map_power(self, expr):
         from pymbolic.primitives import Sum
 
         newbase = self.rec(expr.base)
         if isinstance(expr.base, Product):
-            return self.rec(pymbolic.flattened_product(
-                child**expr.exponent for child in newbase))
+            return self.rec(pymbolic.flattened_product([
+                child**expr.exponent for child in newbase
+                ]))
 
         if isinstance(expr.exponent, int):
             if isinstance(newbase, Sum):

--- a/pymbolic/mapper/evaluator.py
+++ b/pymbolic/mapper/evaluator.py
@@ -190,7 +190,7 @@ class EvaluationMapper(RecursiveMapper, CSECachingMapperMixin):
         return max(self.rec(child) for child in expr.children)
 
     def map_tuple(self, expr):
-        return tuple(self.rec(child) for child in expr)
+        return tuple([self.rec(child) for child in expr])
 
 
 class FloatEvaluationMapper(EvaluationMapper):

--- a/pymbolic/mapper/flattener.py
+++ b/pymbolic/mapper/flattener.py
@@ -26,11 +26,11 @@ from pymbolic.mapper import IdentityMapper
 class FlattenMapper(IdentityMapper):
     def map_sum(self, expr):
         from pymbolic.primitives import flattened_sum
-        return flattened_sum(self.rec(ch) for ch in expr.children)
+        return flattened_sum([self.rec(ch) for ch in expr.children])
 
     def map_product(self, expr):
         from pymbolic.primitives import flattened_product
-        return flattened_product(self.rec(ch) for ch in expr.children)
+        return flattened_product([self.rec(ch) for ch in expr.children])
 
 
 def flatten(expr):

--- a/pymbolic/mapper/stringifier.py
+++ b/pymbolic/mapper/stringifier.py
@@ -156,11 +156,16 @@ class StringifyMapper(pymbolic.mapper.Mapper):
 
     def map_call_with_kwargs(self, expr, enclosing_prec, *args, **kwargs):
         args_strings = (
-                tuple(self.rec(ch, PREC_NONE, *args, **kwargs)
-                      for ch in expr.parameters)
+                tuple([
+                    self.rec(ch, PREC_NONE, *args, **kwargs)
+                    for ch in expr.parameters
+                    ])
                 +  # noqa: W504
-                tuple("{}={}".format(name, self.rec(ch, PREC_NONE, *args, **kwargs))
-                    for name, ch in expr.kw_parameters.items()))
+                tuple([
+                    "{}={}".format(name, self.rec(ch, PREC_NONE, *args, **kwargs))
+                    for name, ch in expr.kw_parameters.items()
+                    ])
+                )
         return self.format("%s(%s)",
                 self.rec(expr.function, PREC_CALL, *args, **kwargs),
                 ", ".join(args_strings))

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -1306,45 +1306,47 @@ class Vector(Expression):
             return Expression.__getitem__(self, index)
 
     def __neg__(self):
-        return Vector(tuple(-x for x in self))
+        return Vector(tuple([-x for x in self]))
 
     def __add__(self, other):
         if len(other) != len(self):
             raise ValueError("can't add values of differing lengths")
-        return Vector(tuple(x+y for x, y in zip(self, other)))
+        return Vector(tuple([x+y for x, y in zip(self, other)]))
 
     def __radd__(self, other):
         if len(other) != len(self):
             raise ValueError("can't add values of differing lengths")
-        return Vector(tuple(y+x for x, y in zip(self, other)))
+        return Vector(tuple([y+x for x, y in zip(self, other)]))
 
     def __sub__(self, other):
         if len(other) != len(self):
             raise ValueError("can't subtract values of differing lengths")
-        return Vector(tuple(x-y for x, y in zip(self, other)))
+        return Vector(tuple([x-y for x, y in zip(self, other)]))
 
     def __rsub__(self, other):
         if len(other) != len(self):
             raise ValueError("can't subtract values of differing lengths")
-        return Vector(tuple(y-x for x, y in zip(self, other)))
+        return Vector(tuple([y-x for x, y in zip(self, other)]))
 
     def __mul__(self, other):
-        return Vector(tuple(x*other for x in self))
+        return Vector(tuple([x*other for x in self]))
 
     def __rmul__(self, other):
-        return Vector(tuple(other*x for x in self))
+        return Vector(tuple([other*x for x in self]))
 
     def __div__(self, other):
         # Py2 only
         import operator
-        return Vector(tuple(operator.div(x, other) for x in self))  # noqa pylint: disable=no-member
+        return Vector(tuple([
+            operator.div(x, other) for x in self    # pylint: disable=no-member
+            ]))
 
     def __truediv__(self, other):
         import operator
-        return Vector(tuple(operator.truediv(x, other) for x in self))
+        return Vector(tuple([operator.truediv(x, other) for x in self]))
 
     def __floordiv__(self, other):
-        return Vector(tuple(x//other for x in self))
+        return Vector(tuple([x//other for x in self]))
 
     def __getinitargs__(self):
         return self.children


### PR DESCRIPTION
The commits should be fairly self-contained. The changes are

* Use `tuple([...])` over `tuple(generator)`, since it's a bit faster and some of these get called a lot.
* Return original expressions if nothing changed in `geometric_algebra.mappers`.
* Add an early exit in `DerivativeBinder.map_product` if it didn't find any nablas.

The only change that had a visible effect (i.e > 1s) was the second one. The main culprit was the hashing and equality comparisons for the various caches and that helped hit the `self is other` case more often and avoid the expensive checks.