### PR TITLE
Do not test against Py3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             uses: actions/setup-python@v1
             with:
                 # matches compat target in setup.py
-                python-version: '3.6'
+                python-version: '3.7'
         -   name: "Main Script"
             run: |
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-flake8.sh
@@ -51,7 +51,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.6", "3.8", "3.9", "3.x"]
+                python-version: ["3.7", "3.8", "3.9", "3.x"]
         steps:
         -   uses: actions/checkout@v2
         -


### PR DESCRIPTION
Reached EOL on 12/23/2021. See https://devguide.python.org/devcycle/#end-of-life-branches