### PR TITLE
Version bump: 2022.1

### DIFF
--- a/pymbolic/version.py
+++ b/pymbolic/version.py
@@ -1,3 +1,3 @@
-VERSION = (2021, 1)
+VERSION = (2022, 1)
 VERSION_STATUS = ""
 VERSION_TEXT = ".".join(str(x) for x in VERSION) + VERSION_STATUS


### PR DESCRIPTION
The new `inducer/loopy` trunk needs the memoized version of mappers. And typically users pull it from pypi. Could we please have a version bump, thanks!