### PR TITLE
matchpy.PymbolicOp: Add variable_name abstractproperty

### DIFF
--- a/pymbolic/interop/matchpy/__init__.py
+++ b/pymbolic/interop/matchpy/__init__.py
@@ -124,6 +124,10 @@ class PymbolicOp(abc.ABC, Operation):
     """
     unpacked_args_to_init: ClassVar[bool] = True
 
+    @abc.abstractproperty
+    def variable_name(self):
+        pass
+
     @property
     def operands(self) -> Tuple[Expression]:
         return tuple(getattr(self, field.name)


### PR DESCRIPTION
Addresses this new bugbear failure: https://github.com/inducer/pymbolic/runs/8055143263?check_suite_focus=true#step:4:80