### PR TITLE
Hack traversals for speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
         strategy:
             matrix:
                 downstream_project: [loopy, grudge, pytential, pytato]
+            fail-fast: false
         name: Tests for downstream project ${{ matrix.downstream_project }}
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         -   name: "Main Script"
             run: |
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-flake8.sh
-                . ./prepare-and-run-flake8.sh pymbolic test
+                . ./prepare-and-run-flake8.sh pymbolic test experiments
 
     pylint:
         name: Pylint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             uses: actions/setup-python@v1
             with:
                 # matches compat target in setup.py
-                python-version: '3.6'
+                python-version: '3.8'
         -   name: "Main Script"
             run: |
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-flake8.sh
@@ -51,7 +51,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.6", "3.8", "3.9", "3.x"]
+                python-version: ["3.8", "3.9", "3.x"]
         steps:
         -   uses: actions/checkout@v2
         -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ Documentation:
 Flake8:
   script:
   - curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-flake8.sh
-  - ". ./prepare-and-run-flake8.sh pymbolic test"
+  - . ./prepare-and-run-flake8.sh pymbolic test experiments
   tags:
   - python3
   except:

--- a/experiments/traversal-benchmark.py
+++ b/experiments/traversal-benchmark.py
@@ -1,8 +1,11 @@
 # See https://github.com/inducer/pymbolic/pull/110 for context
 
+import sys
+
 from pymbolic import parse
 from pymbolic.primitives import Variable
 from pymbolic.mapper import CachedIdentityMapper
+from pymbolic.mapper.optimize import optimize_mapper
 
 
 code = ("(-1)*((cse_577[_pt_data_48[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
@@ -94,6 +97,10 @@ replacements = {
         }
 
 
+@optimize_mapper(drop_args=True, drop_kwargs=True,
+                 # inline_cache=True, inline_rec=True,
+                 inline_get_cache_key=True,
+                 print_modified_code_file=sys.stdout)
 class Renamer(CachedIdentityMapper):
     def map_variable(self, expr):
         return replacements.get(expr.name, expr)

--- a/experiments/traversal-benchmark.py
+++ b/experiments/traversal-benchmark.py
@@ -1,0 +1,129 @@
+# See https://github.com/inducer/pymbolic/pull/110 for context
+
+from pymbolic import parse
+from pymbolic.primitives import Variable
+from pymbolic.mapper import CachedIdentityMapper
+
+
+code = ("(-1)*((cse_577[_pt_data_48[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        "_pt_data_49[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_48[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_577[_pt_data_46[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_47[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_46[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_577[_pt_data_7[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_43[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_7[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_577[_pt_data_44[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_45[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_44[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_579[_pt_data_68[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_69[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_68[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_579[_pt_data_66[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_67[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_66[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_579[_pt_data_50[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_63[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_50[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_579[_pt_data_64[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_65[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_64[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_581[_pt_data_88[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_89[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_88[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_581[_pt_data_86[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_87[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_86[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_581[_pt_data_70[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_83[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_70[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_581[_pt_data_84[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_85[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_84[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_582[_pt_data_107[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_108[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_107[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_582[_pt_data_105[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0],"
+        " _pt_data_106[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_105[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_582[_pt_data_90[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_102[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_90[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_582[_pt_data_103[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_104[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_103[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0))"
+        " + (cse_572[_pt_data_48[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_49[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_48[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0) "
+        "+ (cse_572[_pt_data_46[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_47[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_46[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0) "
+        "+ (cse_572[_pt_data_7[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_43[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_7[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_572[_pt_data_44[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_45[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_44[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_573[_pt_data_68[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_69[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_68[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_573[_pt_data_66[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_67[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_66[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_573[_pt_data_50[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_63[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_50[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_573[_pt_data_64[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_65[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_64[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_574[_pt_data_88[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_89[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_88[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_574[_pt_data_86[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_87[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_86[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0) "
+        "+ (cse_574[_pt_data_70[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_83[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_70[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_574[_pt_data_84[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_85[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_84[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_575[_pt_data_107[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_108[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_107[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_575[_pt_data_105[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_106[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_105[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_575[_pt_data_90[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_102[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_90[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        " + (cse_575[_pt_data_103[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0], _pt_data_104[(iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 10]]"
+        " if _pt_data_103[((iface_ensm15*1075540 + iel_ensm15*10 + idof_ensm15) % 4302160) // 10, 0] != -1 else 0)"
+        )
+
+expr = parse(code)
+expr = CachedIdentityMapper()(expr)  # remove duplicate nodes
+
+
+replacements = {
+        "iface_ensm15": Variable("_0"),
+        "iel_ensm15": Variable("_1"),
+        "idof_ensm15": Variable("_2"),
+        }
+
+
+class Renamer(CachedIdentityMapper):
+    def map_variable(self, expr):
+        return replacements.get(expr.name, expr)
+
+    def get_cache_key(self, expr):
+        # Must add 'type(expr)', to differentiate between python scalar types.
+        # In Python, the following conditions are true: "hash(4) == hash(4.0)"
+        # and "4 == 4.0", but their traversal results cannot be re-used.
+        return (type(expr), expr)
+
+
+def main():
+    mapper = Renamer()
+    mapper(expr)
+    # print(type(new_expr))
+
+
+if __name__ == "__main__":
+    from time import time
+
+    if 1:
+        t_start = time()
+        for _ in range(10_000):
+            main()
+        t_end = time()
+        print(f"Took: {t_end-t_start} secs.")
+    else:
+        import vmprof
+        with open("test.prof", "w+b") as fd:
+            vmprof.enable(fd.fileno())
+            for _ in range(10_000):
+                main()
+            vmprof.disable()

--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -500,17 +500,9 @@ class IdentityMapper(Mapper):
                 for child, orig_child in zip(children, expr.children)):
             return expr
 
-        from pymbolic.primitives import flattened_sum
-        return flattened_sum(children)
+        return type(expr)(tuple(children))
 
-    def map_product(self, expr, *args, **kwargs):
-        children = [self.rec(child, *args, **kwargs) for child in expr.children]
-        if all(child is orig_child
-                for child, orig_child in zip(children, expr.children)):
-            return expr
-
-        from pymbolic.primitives import flattened_product
-        return flattened_product(children)
+    map_product = map_sum
 
     def map_quotient(self, expr, *args, **kwargs):
         numerator = self.rec(expr.numerator, *args, **kwargs)

--- a/pymbolic/mapper/optimize.py
+++ b/pymbolic/mapper/optimize.py
@@ -1,0 +1,364 @@
+__copyright__ = "Copyright (C) 2022 University of Illinois Board of Trustees"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import ast
+from functools import lru_cache
+
+
+# This machinery applies AST rewriting to the mapper in a mildly brutal
+# manner, and as such it requires some attention from the user to
+# make sure all transformations applied are valid. A good way to do
+# this is to look at the generated code by settting print_modified_code_file
+# to sys.stdout or the like.
+
+# Note that this machinery is intentionally generic enough so as to also
+# apply to pytato's mappers in unmodified form.
+
+
+# {{{ ast retrieval
+
+def _get_def_from_ast_container(container, name, node_type):
+    for entry in container:
+        if isinstance(entry, node_type) and entry.name == name:
+            return entry
+
+    raise ValueError(f"symbol '{name}' not found")
+
+
+@lru_cache
+def _get_ast_for_file(filename):
+    with open(filename, "r") as inf:
+        return ast.parse(inf.read(), filename)
+
+
+def _get_file_name_for_module_name(module_name):
+    from importlib import import_module
+    return import_module(module_name).__file__
+
+
+def _get_ast_for_module_name(module_name):
+    return _get_ast_for_file(_get_file_name_for_module_name(module_name))
+
+
+def _get_module_ast_for_object(obj):
+    return _get_ast_for_module_name(obj.__module__)
+
+
+def _get_ast_for_class(cls):
+    mod_ast = _get_module_ast_for_object(cls)
+    return _get_def_from_ast_container(
+            mod_ast.body, cls.__name__, ast.ClassDef)
+
+
+def _get_ast_for_method(f):
+    dot_components = f.__qualname__.split(".")
+    assert dot_components[-1] == f.__name__
+    cls_name, = dot_components[:-1]
+    mod_ast = _get_ast_for_module_name(f.__module__)
+    cls_ast = _get_def_from_ast_container(
+            mod_ast.body, cls_name, ast.ClassDef)
+    return _get_def_from_ast_container(
+            cls_ast.body, f.__name__, ast.FunctionDef)
+
+# }}}
+
+
+def _replace(obj, **kwargs):
+    try:
+        kwargs["lineno"] = obj.lineno
+    except AttributeError:
+        pass
+    try:
+        kwargs["col_offsets"] = obj.col_offsets
+    except AttributeError:
+        pass
+
+    return type(obj)(**{
+        name: kwargs.get(name, getattr(obj, name))
+        for name in set(obj._fields) | set(kwargs.keys())
+        })
+
+
+class _VarArgsRemover(ast.NodeTransformer):
+    def __init__(self, drop_args, drop_kwargs):
+        self.drop_args = drop_args
+        self.drop_kwargs = drop_kwargs
+
+    def visit_Call(self, node):  # noqa: N802
+        node = self.generic_visit(node)
+        return _replace(node,
+                       args=[arg for arg in node.args
+                          if not self.drop_args or not isinstance(arg, ast.Starred)],
+                       keywords=[kw for kw in node.keywords
+                          if not self.drop_kwargs or kw.arg is not None])
+
+
+class _RecInliner(ast.NodeTransformer):
+    def __init__(self, *, inline_rec, inline_cache):
+        self.inline_rec = inline_rec
+        self.inline_cache = inline_cache
+
+    def visit_Call(self, node):  # noqa: N802
+        node = self.generic_visit(node)
+
+        result_expr = node
+
+        if (isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr == "rec"):
+
+            from ast import (IfExp, Name, NamedExpr, Compare, IsNot, Constant,
+                             Load, Store, Attribute, Call)
+            expr = node.args[0]
+            self_sym = Name(id="self", ctx=Load())
+            fallback_call = _replace(
+                    node,
+                    func=Attribute(value=self_sym, attr="rec_fallback", ctx=Load()))
+
+            def getattr_sym(obj, name):
+                return Call(
+                        func=Name(id="getattr", ctx=Load()),
+                        args=[obj, name, Constant(value=None)], keywords=[])
+
+            def is_not_none(obj):
+                return Compare(
+                        left=obj, ops=[IsNot()], comparators=[Constant(value=None)])
+
+            def expr_assign(name, value):
+                return NamedExpr(
+                        target=Name(id=name, ctx=Store()),
+                        value=value)
+
+            if self.inline_rec:
+                result_expr = IfExp(
+                    test=is_not_none(
+                        expr_assign("mname",
+                            getattr_sym(expr, Constant(value="mapper_method")))),
+                    body=IfExp(
+                        test=is_not_none(
+                            expr_assign("method", getattr_sym(
+                                    self_sym, Name(id="mname", ctx=Load())))),
+                        body=_replace(node, func=Name(id="method", ctx=Load())),
+                        orelse=fallback_call),
+                    orelse=fallback_call)
+
+            if self.inline_cache:
+                cache = Attribute(value=self_sym, attr="_cache")
+                expr_type = Call(
+                        func=Name(id="type", ctx=Load()),
+                        args=[expr],
+                        keywords=[])
+                cache_key_expr = ast.Tuple([expr_type, expr], ctx=Load())
+                nic = Name(id="_NOT_IN_CACHE", ctx=Load())
+
+                result_expr = IfExp(
+                        test=Compare(
+                            left=expr_assign(
+                                "result",
+                                Call(
+                                    func=Attribute(value=cache, attr="get"),
+                                    args=[
+                                        expr_assign(
+                                            "cache_key",
+                                            cache_key_expr),
+                                        nic
+                                        ], keywords=[])),
+                                ops=[IsNot()], comparators=[nic]),
+                        body=Name(id="result", ctx=Load()),
+                        orelse=Call(
+                            func=Name(id="_set_and_return", ctx=Load()),
+                            args=[cache,
+                                    Name(id="cache_key", ctx=Load()),
+                                    result_expr], keywords=[]))
+
+        return result_expr
+
+
+def _get_cache_key_expr(mdef):
+    for stmt in mdef.body:
+        if isinstance(stmt, ast.Expr):
+            # assume no side effects, likely a docstring
+            pass
+        elif isinstance(stmt, ast.Return):
+            return stmt.value
+        else:
+            raise ValueError("unexpected statement type in get_cache_key: "
+                             "{type(stmt).__name__} --- must only contain a single "
+                             "return statement")
+
+
+class _CacheKeyInliner(ast.NodeTransformer):
+    def __init__(self, *, cache_key_expr):
+        self.cache_key_expr = cache_key_expr
+
+    def visit_Call(self, node):  # noqa: N802
+        node = self.generic_visit(node)
+
+        result_expr = node
+
+        if (isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr == "get_cache_key"):
+            result_expr = self.cache_key_expr
+
+        return result_expr
+
+
+def _set_and_return(mapping, key, value):
+    mapping[key] = value
+    return value
+
+
+def optimize_mapper(
+        *, drop_args=False, drop_kwargs=False,
+        inline_rec=False, inline_cache=False, inline_get_cache_key=False,
+        print_modified_code_file=None):
+    """
+    :param print_modified_code_file: a file-like object to which the modified
+        code will be printed, or ``None``.
+    """
+    # This is a crime, an abomination. But a somewhat effective one.
+
+    def wrapper(cls):
+        try:
+            # Introduced in Py3.9
+            ast.unparse
+        except AttributeError:
+            return cls
+
+        # This also needs Py3.8 for the walrus operators used in inlined rec.
+
+        cls_ast = _get_ast_for_class(cls)
+
+        # {{{ gather relevant method definitions
+
+        method_defs = {}
+        other_contents = []
+
+        for entry in cls_ast.body:
+            if isinstance(entry, ast.FunctionDef):
+                method_defs[entry.name] = entry
+            else:
+                other_contents.append(entry)
+
+        seen_module_names = set()
+
+        # Yes, this grabs the source for all methods, including those
+        # from the base classes, and rewrites them. Otherwise, those methods
+        # would still use have *args, **kwargs.
+        for name in dir(cls):
+            if not name.startswith("__") or name == "__call__":
+                method = getattr(cls, name)
+                seen_module_names.add(method.__module__)
+                method_ast = _get_ast_for_method(method)
+                if name != method_ast.name:
+                    # This happens for aliases. Make them separate methods.
+                    method_ast = _replace(method_ast, name=name)
+
+                method_defs[method_ast.name] = method_ast
+
+        # }}}
+
+        # {{{ get expression for get_cache_key
+
+        cache_key_expr = None
+        if inline_get_cache_key and "get_cache_key" in method_defs:
+            cache_key_expr = _get_cache_key_expr(method_defs["get_cache_key"])
+
+        if inline_get_cache_key and cache_key_expr is None:
+            raise ValueError("could not find expression for cache key")
+
+        # }}}
+
+        # {{{ rewrite method_defs
+
+        new_method_defs = []
+
+        for mname in sorted(method_defs):
+            mdef = method_defs[mname]
+
+            mdef = _replace(mdef,
+                    args=_replace(mdef.args,
+                        vararg=None if drop_args else mdef.args.vararg,
+                        kwarg=None if drop_kwargs else mdef.args.kwarg))
+
+            mdef = _VarArgsRemover(
+                    drop_args=drop_args, drop_kwargs=drop_kwargs).visit(mdef)
+
+            if cache_key_expr is not None:
+                mdef = _CacheKeyInliner(cache_key_expr=cache_key_expr).visit(mdef)
+
+            mdef = _RecInliner(
+                    inline_rec=inline_rec, inline_cache=inline_cache).visit(mdef)
+
+            ast.fix_missing_locations(mdef)
+
+            new_method_defs.append(mdef)
+
+        cls_ast = _replace(
+                cls_ast,
+                # other contents second so method aliases work
+                body=new_method_defs + other_contents,
+                # FIXME: only remove optimize_mapper from decorators
+                decorator_list=[])
+
+        # }}}
+
+        code_str = ast.unparse(cls_ast)
+        if print_modified_code_file:
+            print(code_str, file=print_modified_code_file)
+
+        compile_dict = {
+                "_MODULE_SOURCE_CODE": code_str,
+                "_set_and_return": _set_and_return,
+                }
+
+        # {{{ gather symbols from modules from which methods were collected
+
+        from importlib import import_module
+        for mod_name in seen_module_names:
+            for name, value in import_module(mod_name).__dict__.items():
+                if name.startswith("__"):
+                    continue
+                if name in compile_dict:
+                    if compile_dict[name] is not value:
+                        raise ValueError(
+                                "symbol disagreement in environment: "
+                                f"'{name}', most recently from '{mod_name}'")
+                compile_dict[name] = value
+
+        # }}}
+
+        exec(compile(
+            code_str,
+            f"<'{_get_file_name_for_module_name(cls.__module__)}' "
+            "modified by optimize_mapper>",
+            "exec"),
+             compile_dict)
+
+        return compile_dict[cls.__name__]
+
+    return wrapper
+
+# vim: foldmethod=marker

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,8 @@ inline-quotes = "
 docstring-quotes = """
 multiline-quotes = """
 
+
+per-file-ignores=
+        experiments/traversal-benchmark.py:E501
+
 # enable-flake8-bugbear

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name="pymbolic",
       url="http://mathema.tician.de/software/pymbolic",
 
       packages=find_packages(),
-      python_requires="~=3.6",
+      python_requires="~=3.8",
       install_requires=[
           "pytools>=2",
           "pytest>=2.3",

--- a/test/test_pymbolic.py
+++ b/test/test_pymbolic.py
@@ -938,6 +938,23 @@ def test_cached_mapper_differentiates_float_int():
 # }}}
 
 
+# {{{ test_mapper_optimizer
+
+def test_mapper_optimizer():
+    from testlib import Renamer, OptimizedRenamer, BIG_EXPR_STR
+    from pymbolic.mapper import CachedIdentityMapper
+
+    expr = parse(BIG_EXPR_STR)
+    expr = CachedIdentityMapper()(expr)  # remove duplicate nodes
+
+    result_ref = Renamer()(expr)
+    result_opt = OptimizedRenamer()(expr)
+
+    assert result_ref == result_opt
+
+# }}}
+
+
 def test_nodecount():
     from pymbolic.mapper.analysis import get_num_nodes
     expr = prim.Sum((4, 4.0))


### PR DESCRIPTION
There's actually a path towards merging this now.
- [x] It would need tests.
- [x] The mapper optimizer needs a way to inline the cache key, so that we don't have to hardcode it.
- [ ] ~~The mapper optimizer needs documentation.~~ (Decided against this; it requires a fair bit of care to use, and the sharp edges may not be obvious to users. Added a comment.)

The root of this is [this contest](https://gist.github.com/kaushikcfd/74c442a075557dad466cd3daea9c151f) set up by @kaushikcfd to show that we should all abandon Python for Rust (or some other AOT statically-typed language).

Here's my fork of @kaushikcfd's gist: https://gist.github.com/inducer/25e3372fd5c82384d437c777ed4153e9

Latest results:
- Starting point for me was 5.18s, which is @kaushikcfd's original with the `print` statements removed.
- I'm currently at 1.6s. I *am* cheating and giving myself credit for the Py3.10 -> Py3.11 transition, but since this is all about changing languages, I guess fair is fair.