### PR TITLE
get_cache_key: replace sorted() with immutable Map

### DIFF
--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 import pymbolic.primitives as primitives
+import immutables
 
 __doc__ = """
 Basic dispatch
@@ -251,7 +252,7 @@ class CachedMapper(Mapper):
         # Must add 'type(expr)', to differentiate between python scalar types.
         # In Python, the following conditions are true: "hash(4) == hash(4.0)"
         # and "4 == 4.0", but their traversal results cannot be re-used.
-        return (type(expr), expr, args, tuple(sorted(kwargs.items())))
+        return (type(expr), expr, args, immutables.Map(kwargs))
 
     def __call__(self, expr, *args, **kwargs):
         result = self._cache.get(

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(name="pymbolic",
       python_requires="~=3.8",
       install_requires=[
           "pytools>=2022.1.14",
+          "immutables",
           ],
       extras_require={
           "test": ["pytest>=2.3"],


### PR DESCRIPTION
`sorted()` is currently the function with the highest impact on compile performance in a mirgecom-y3prediction rhs compile on M1 (i.e., it is the top entry in cProfile when sorting by `tottime`, just above islpy's casting wrapper). This PR reduces the number of calls to `sorted` by 80%.

Other options might be:
- use `frozenset`
- use `hash(immutables.Map(...))`
- use `frozendict`