### PR TITLE
tests: fix random graph hash

### DIFF
--- a/test/testlib.py
+++ b/test/testlib.py
@@ -46,7 +46,7 @@ def _generate_random_expr_inner(
 
     if context.current_depth >= context.max_depth:
         # force expression to be a leaf type
-        return context.rng.integers(0, 42)
+        return int(context.rng.integers(0, 42))
 
     bucket = context.rng.integers(0, 100) / 100.0
 


### PR DESCRIPTION
Seems like there was a numpy int that snuck in there and something changed about its hash in 2.0.

EDIT: It was actually this: the repr for an `np.int64(3)` changed from `'3'` to `'np.int64(3)'`
```
    def map_constant(self, expr):
        self.key_hash.update(repr(expr).encode("utf8"))
```
Should the `PersistentHashWalkMapper` be changed instead?