### PR TITLE
PersistentHashWalkMapper: do not ignore comparison operator

### DIFF
--- a/pymbolic/mapper/persistent_hash.py
+++ b/pymbolic/mapper/persistent_hash.py
@@ -49,3 +49,9 @@ class PersistentHashWalkMapper(WalkMapper):
                 expr = expr.item()
 
         self.key_hash.update(repr(expr).encode("utf8"))
+
+    def map_comparison(self, expr):
+        if self.visit(expr):
+            self.rec(expr.left)
+            self.key_hash.update(repr(expr.operator).encode("utf8"))
+            self.rec(expr.right)


### PR DESCRIPTION
Consider the following example:

```python
from pymbolic.primitives import Comparison, Variable

from pymbolic.mapper.persistent_hash import PersistentHashWalkMapper
from hashlib import sha256

expr1 = Comparison(Variable('_in0'), '<', Variable('_in1'))
expr2 = Comparison(Variable('_in0'), '>', Variable('_in1'))  # only differ in operator

pm1 = PersistentHashWalkMapper(sha256())
pm2 = PersistentHashWalkMapper(sha256())

pm1(expr1)
print(f"{pm1.key_hash.hexdigest()=}")

pm2(expr2)
print(f"{pm2.key_hash.hexdigest()=}")
```

before:
```
pm1.key_hash.hexdigest()='53780ab5ba3e7dc99573958a5a54fa8ed3f88972ab670832c1915653853bc0c4'
pm2.key_hash.hexdigest()='53780ab5ba3e7dc99573958a5a54fa8ed3f88972ab670832c1915653853bc0c4'  # same hash
```

after:
```
pm1.key_hash.hexdigest()='1a9b95805d65a0336e03cc7d8e2b7b2f335b1171b8d9e4743263ea2bc6e7763e'
pm2.key_hash.hexdigest()='9d3fa846784ec819667ea13b1447ef440dc994501a87c58f6fd9c0f66ddc4fbe'
```

(I guess there may be more occurrences of this kind of issue?)