### PR TITLE
Add explicit scopes to CSE

### DIFF
--- a/pymbolic/algorithm.py
+++ b/pymbolic/algorithm.py
@@ -272,10 +272,12 @@ def sym_fft(x, sign=1):
 
     def wrap_intermediate(x):
         if len(x) > 1:
-            from pymbolic.primitives import CommonSubexpression
+            from pymbolic.primitives import CommonSubexpression, cse_scope
+
             result = numpy.empty(len(x), dtype=object)
             for i, x_i in enumerate(x):
-                result[i] = CommonSubexpression(x_i)
+                result[i] = CommonSubexpression(x_i, scope=cse_scope.EVALUATION)
+
             return result
         else:
             return x

--- a/pymbolic/cse.py
+++ b/pymbolic/cse.py
@@ -120,7 +120,8 @@ class CSEMapper(IdentityMapper):
             if type(result) is prim.CommonSubexpression:
                 result = result.child
 
-            return type(expr)(result, expr.prefix, **expr.get_extra_properties())
+            return type(expr)(result, expr.prefix, expr.scope,
+                              **expr.get_extra_properties())
 
     def map_substitution(self, expr):
         return type(expr)(

--- a/pymbolic/cse.py
+++ b/pymbolic/cse.py
@@ -90,8 +90,9 @@ class CSEMapper(IdentityMapper):
         try:
             return self.canonical_subexprs[key]
         except KeyError:
-            new_expr = prim.wrap_in_cse(
-                    getattr(IdentityMapper, expr.mapper_method)(self, expr))
+            new_expr = prim.make_common_subexpression(
+                    getattr(IdentityMapper, expr.mapper_method)(self, expr)
+                    )
             self.canonical_subexprs[key] = new_expr
             return new_expr
 
@@ -113,7 +114,9 @@ class CSEMapper(IdentityMapper):
     def map_common_subexpression(self, expr):
         # Avoid creating CSE(CSE(...))
         if type(expr) is prim.CommonSubexpression:
-            return prim.wrap_in_cse(self.rec(expr.child), expr.prefix)
+            return prim.make_common_subexpression(
+                self.rec(expr.child), expr.prefix, expr.scope
+                )
         else:
             # expr is of a derived CSE type
             result = self.rec(expr.child)

--- a/pymbolic/interop/symengine.py
+++ b/pymbolic/interop/symengine.py
@@ -92,7 +92,8 @@ class SymEngineToPymbolicMapper(SympyLikeToPymbolicMapper):
                 self.rec(expr.args[0]), sympy_expr.prefix, sympy_expr.scope)
         elif isinstance(expr, symengine.Function) and \
                 self.function_name(expr) == "CSE":
-            return prim.CommonSubexpression(self.rec(expr.args[0]))
+            return prim.CommonSubexpression(
+                self.rec(expr.args[0]), scope=prim.cse_scope.EVALUATION)
         return SympyLikeToPymbolicMapper.not_supported(self, expr)
 
 # }}}

--- a/pymbolic/mapper/c_code.py
+++ b/pymbolic/mapper/c_code.py
@@ -44,15 +44,16 @@ class CCodeMapper(SimplifyingSortingStringifyMapper):
     .. doctest::
 
         >>> import pymbolic.primitives as p
+        >>> CSE = p.make_common_subexpression
         >>> x = p.Variable("x")
-        >>> CSE = p.CommonSubexpression
         >>> u = CSE(3*x**2-5, "u")
         >>> expr = u/(u+3)*(u+5)
         >>> print(expr)
         (CSE(3*x**2 + -5) / (CSE(3*x**2 + -5) + 3))*(CSE(3*x**2 + -5) + 5)
 
-    Notice that if we were to directly generate code from this, the
-    subexpression *u* would be evaluated multiple times.
+    Notice that if we were to directly generate this code without the added
+    `CSE`, the subexpression *u* would be evaluated multiple times. Wrapping the
+    expression as above avoids this unnecessary cost.
 
     .. doctest::
 

--- a/pymbolic/mapper/cse_tagger.py
+++ b/pymbolic/mapper/cse_tagger.py
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 
 from pymbolic.mapper import IdentityMapper, WalkMapper
-from pymbolic.primitives import CommonSubexpression
+from pymbolic.primitives import CommonSubexpression, cse_scope
 
 
 class CSEWalkMapper(WalkMapper):
@@ -43,10 +43,9 @@ class CSETagMapper(IdentityMapper):
 
     def map_call(self, expr):
         if self.subexpr_histogram.get(expr, 0) > 1:
-            return CommonSubexpression(expr)
+            return CommonSubexpression(expr, scope=cse_scope.EVALUATION)
         else:
-            return getattr(IdentityMapper, expr.mapper_method)(
-                    self, expr)
+            return getattr(IdentityMapper, expr.mapper_method)(self, expr)
 
     map_sum = map_call
     map_product = map_call

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -729,8 +729,7 @@ class Expression:
         depr_key = (type(self), "__eq__")
         if depr_key not in self._deprecation_warnings_issued:
             warn(f"Expression.__eq__ is used by {self.__class__}. This is deprecated. "
-                 "Use equality comparison supplied by expr_dataclass"
-                 "instead. "
+                 "Use equality comparison supplied by expr_dataclass instead. "
                  "This will stop working in 2025.",
                  DeprecationWarning, stacklevel=2)
             self._deprecation_warnings_issued.add(depr_key)
@@ -981,8 +980,9 @@ def _augment_expression_dataclass(
         def {cls.__name__}_init_arg_names(self):
             depr_key = (type(self), "init_arg_names")
             if depr_key not in self._deprecation_warnings_issued:
-                warn("__getinitargs__ is deprecated and will be removed in 2025. "
-                        "Use dataclasses.fields instead.",
+                warn("Attribute 'init_arg_names' of {cls} is deprecated and will "
+                        "not have a default implementation starting from 2025. "
+                        "Use 'dataclasses.fields' instead.",
                         DeprecationWarning, stacklevel=2)
 
                 self._deprecation_warnings_issued.add(depr_key)
@@ -995,8 +995,9 @@ def _augment_expression_dataclass(
         def {cls.__name__}_getinitargs(self):
             depr_key = (type(self), "__getinitargs__")
             if depr_key not in self._deprecation_warnings_issued:
-                warn("__getinitargs__ is deprecated and will be removed in 2025. "
-                        "Use dataclasses.fields instead.",
+                warn("Method '__getinitargs__' of {cls} is deprecated and will "
+                        "not have a default implementation starting from 2025. "
+                        "Use 'dataclasses.fields' instead.",
                         DeprecationWarning, stacklevel=2)
 
                 self._deprecation_warnings_issued.add(depr_key)

--- a/test/test_pymbolic.py
+++ b/test/test_pymbolic.py
@@ -730,7 +730,7 @@ def test_flop_counter():
     y = prim.Variable("y")
     z = prim.Variable("z")
 
-    subexpr = prim.CommonSubexpression(3 * (x**2 + y + z))
+    subexpr = prim.make_common_subexpression(3 * (x**2 + y + z))
     expr = 3*subexpr + subexpr
 
     from pymbolic.mapper.flop_counter import CSEAwareFlopCounter, FlopCounter
@@ -802,7 +802,7 @@ def test_diff_cse():
     m = prim.Variable("math")
 
     x = prim.Variable("x")
-    cse = prim.CommonSubexpression(x**2 + 1)
+    cse = prim.make_common_subexpression(x**2 + 1)
     expr = m.attr("exp")(cse)*m.attr("sin")(cse**2)
 
     diff_result = differentiate(expr, x)
@@ -1016,7 +1016,7 @@ def test_nodecount():
     y = prim.Variable("y")
     z = prim.Variable("z")
 
-    subexpr = prim.CommonSubexpression(4 * (x**2 + y + z))
+    subexpr = prim.make_common_subexpression(4 * (x**2 + y + z))
     expr = 3*subexpr + subexpr + subexpr + subexpr
     expr = expr + expr + expr
 


### PR DESCRIPTION
There are quite a few deprecation warnings from that, so this adds the explicit scopes in mappers and others things.

I didn't add it in `make_common_subexpression`. Should that also defaults to `EVALUATION` now? As a "helper" function, I would sort of expect it to do the right thing™ (?).