### PR TITLE
Various typing/`dataclasses` fixes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,4 +24,10 @@ intersphinx_mapping = {
     "sympy": ("https://docs.sympy.org/dev/", None),
     "typing_extensions":
         ("https://typing-extensions.readthedocs.io/en/latest/", None),
+    "immutabledict":
+        ("https://immutabledict.corenting.fr/", None)
+}
+autodoc_type_aliases = {
+    "ExpressionT": "ExpressionT",
+    "ArithmeticExpressionT": "ArithmeticExpressionT",
 }

--- a/doc/primitives.rst
+++ b/doc/primitives.rst
@@ -1,6 +1,7 @@
 Primitives (Basic Objects)
 ==========================
 
+.. automodule:: pymbolic.typing
 .. automodule:: pymbolic.primitives
 
 .. vim: sw=4

--- a/pymbolic/__init__.py
+++ b/pymbolic/__init__.py
@@ -40,16 +40,20 @@ from . import primitives
 
 from .polynomial import Polynomial
 
-from .primitives import Variable as var  # noqa: N813
-from .primitives import variables
-from .primitives import flattened_sum
-from .primitives import subscript
-from .primitives import flattened_product
-from .primitives import quotient
-from .primitives import linear_combination
-from .primitives import make_common_subexpression as cse
-from .primitives import make_sym_vector
-from .primitives import disable_subscript_by_getitem
+from .primitives import (Variable as var,  # noqa: N813
+    Variable,
+    Expression,
+    variables,
+    flattened_sum,
+    subscript,
+    flattened_product,
+    quotient,
+    linear_combination,
+    make_common_subexpression as cse,
+    make_sym_vector,
+    disable_subscript_by_getitem,
+    expr_dataclass,
+)
 from .parser import parse
 from .mapper.evaluator import evaluate
 from .mapper.evaluator import evaluate_kw
@@ -60,10 +64,18 @@ from .mapper.differentiator import differentiate
 from .mapper.distributor import distribute as expand
 from .mapper.distributor import distribute
 from .mapper.flattener import flatten
+from .typing import NumberT, ScalarT, ArithmeticExpressionT, ExpressionT, BoolT
 
 
 __all__ = (
+    "ArithmeticExpressionT",
+    "BoolT",
+    "Expression",
+    "ExpressionT",
+    "NumberT",
     "Polynomial",
+    "ScalarT",
+    "Variable",
     "compile",
     "compiler",
     "cse",
@@ -78,6 +90,7 @@ __all__ = (
     "evaluate_kw",
     "evaluator",
     "expand",
+    "expr_dataclass",
     "flatten",
     "flattened_product",
     "flattened_sum",

--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -49,7 +49,7 @@ Basic dispatch
     .. rubric:: Handling objects that don't declare mapper methods
 
     In particular, this includes many non-subclasses of
-    :class:`pymbolic.primitives.Expression`.
+    :class:`pymbolic.Expression`.
 
     .. automethod:: map_foreign
 
@@ -113,16 +113,16 @@ class UnsupportedExpressionError(ValueError):
 # {{{ mapper base
 
 class Mapper:
-    """A visitor for trees of :class:`pymbolic.primitives.Expression`
+    """A visitor for trees of :class:`pymbolic.Expression`
     subclasses. Each expression-derived object is dispatched to the
-    method named by the :attr:`pymbolic.primitives.Expression.mapper_method`
+    method named by the :attr:`pymbolic.Expression.mapper_method`
     attribute and if not found, the methods named by the class attribute
     *mapper_method* in the method resolution order of the object.
     """
 
     def handle_unsupported_expression(self, expr, *args, **kwargs):
         """Mapper method that is invoked for
-        :class:`pymbolic.primitives.Expression` subclasses for which a mapper
+        :class:`pymbolic.Expression` subclasses for which a mapper
         method does not exist in this mapper.
         """
 

--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -496,9 +496,9 @@ class IdentityMapper(Mapper):
         parameters = tuple([
             self.rec(child, *args, **kwargs) for child in expr.parameters
             ])
-        kw_parameters = {
+        kw_parameters = immutabledict({
                 key: self.rec(val, *args, **kwargs)
-                for key, val in expr.kw_parameters.items()}
+                for key, val in expr.kw_parameters.items()})
 
         if (function is expr.function
             and all(child is orig_child for child, orig_child in

--- a/pymbolic/mapper/stringifier.py
+++ b/pymbolic/mapper/stringifier.py
@@ -84,11 +84,11 @@ PREC_NONE = 0
 class StringifyMapper(Mapper):
     """A mapper to turn an expression tree into a string.
 
-    :class:`pymbolic.primitives.Expression.__str__` is often implemented using
+    :class:`pymbolic.Expression.__str__` is often implemented using
     this mapper.
 
-    When it encounters an unsupported :class:`pymbolic.primitives.Expression`
-    subclass, it calls its :meth:`pymbolic.primitives.Expression.make_stringifier`
+    When it encounters an unsupported :class:`pymbolic.Expression`
+    subclass, it calls its :meth:`pymbolic.Expression.make_stringifier`
     method to get a :class:`StringifyMapper` that potentially does.
     """
 

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -38,6 +38,7 @@ from typing import (
 )
 from warnings import warn
 
+from immutabledict import immutabledict
 from typing_extensions import TypeIs, dataclass_transform
 
 from . import traits
@@ -1111,6 +1112,17 @@ class CallWithKwargs(AlgebraicLeaf):
     function: ExpressionT
     parameters: tuple[ExpressionT, ...]
     kw_parameters: Mapping[str, ExpressionT]
+
+    def __post_init__(self):
+        try:
+            hash(self.kw_parameters)
+        except Exception:
+            warn("CallWithKwargs created with non-hashable kw_parameters. "
+                 "This is deprecated and will stop working in 2025. "
+                 "If you need an immutable mapping, try the immutabledcit package.",
+                 DeprecationWarning, stacklevel=3
+             )
+            object.__setattr__(self, "kw_parameters", immutabledict(self.kw_parameters))
 
 
 @expr_dataclass()

--- a/pymbolic/typing.py
+++ b/pymbolic/typing.py
@@ -73,13 +73,10 @@ else:
 NumberT: TypeAlias = Union[IntegerT, InexactNumberT]
 ScalarT: TypeAlias = Union[NumberT, BoolT]
 
-# FIXME: This only allows nesting tuples one-deep. When attempting to fix this, there
-# are complaints about recursive type aliases.
-
 _ScalarOrExpression = Union[ScalarT, "Expression"]
 ArithmeticExpressionT: TypeAlias = Union[NumberT, "Expression"]
 
-ExpressionT: TypeAlias = Union[_ScalarOrExpression, Tuple[_ScalarOrExpression, ...]]
+ExpressionT: TypeAlias = Union[_ScalarOrExpression, Tuple["ExpressionT", ...]]
 
 
 T = TypeVar("T")

--- a/pymbolic/typing.py
+++ b/pymbolic/typing.py
@@ -1,3 +1,21 @@
+"""
+.. currentmodule:: pymbolic
+
+Typing helpers
+--------------
+
+.. autoclass:: BoolT
+.. autoclass:: NumberT
+.. autoclass:: ScalarT
+.. autoclass:: ArithmeticExpressionT
+
+    A narrower type alias than :class:`ExpressionT` that is returned by
+    arithmetic operators, to allow continue doing arithmetic with the result
+    of arithmetic.
+
+.. autoclass:: ExpressionT
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, TypeVar, Union
@@ -55,9 +73,12 @@ else:
 NumberT: TypeAlias = Union[IntegerT, InexactNumberT]
 ScalarT: TypeAlias = Union[NumberT, BoolT]
 
+# FIXME: This only allows nesting tuples one-deep. When attempting to fix this, there
+# are complaints about recursive type aliases.
 
 _ScalarOrExpression = Union[ScalarT, "Expression"]
 ArithmeticExpressionT: TypeAlias = Union[NumberT, "Expression"]
+
 ExpressionT: TypeAlias = Union[_ScalarOrExpression, Tuple[_ScalarOrExpression, ...]]
 
 

--- a/pymbolic/typing.py
+++ b/pymbolic/typing.py
@@ -57,6 +57,7 @@ ScalarT: TypeAlias = Union[NumberT, BoolT]
 
 
 _ScalarOrExpression = Union[ScalarT, "Expression"]
+ArithmeticExpressionT: TypeAlias = Union[NumberT, "Expression"]
 ExpressionT: TypeAlias = Union[_ScalarOrExpression, Tuple[_ScalarOrExpression, ...]]
 
 


### PR DESCRIPTION
This contains:

- Fixes needed for Loopy to pass typechecking
- Fixes for a compatibility issue (regarding mutability of `CallWithKwargs.kw_parameters`) that broke leap and dagrt.
- Documentation improvements