### PR TITLE
Add descend_args to DependencyMapper types

### DIFF
--- a/pymbolic/interop/ast.py
+++ b/pymbolic/interop/ast.py
@@ -462,7 +462,8 @@ def to_evaluatable_python_function(expr: ExpressionT,
 
     unparse = ast.unparse
 
-    dep_mapper = CachedDependencyMapper(composite_leaves=True)
+    dep_mapper: CachedDependencyMapper[[]] = (
+        CachedDependencyMapper(composite_leaves=True))
     deps = sorted({dep.name for dep in dep_mapper(expr)})
 
     ast_func = ast.FunctionDef(name=fn_name,

--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -429,7 +429,7 @@ class CachedMapper(Mapper[ResultT, P]):
         method_name = getattr(expr, "mapper_method", None)
         if method_name is not None:
             method = cast(
-                Callable[Concatenate[ExpressionT, P], ResultT],
+                Callable[Concatenate[ExpressionT, P], ResultT] | None,
                 getattr(self, method_name, None)
                 )
             if method is not None:

--- a/pymbolic/mapper/dependency.py
+++ b/pymbolic/mapper/dependency.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 """
 
 from collections.abc import Set
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 import pymbolic.primitives as p
 from pymbolic.mapper import CachedMapper, Collector, CSECachingMapperMixin, P
@@ -53,10 +53,10 @@ class DependencyMapper(
         self,
         include_subscripts: bool = True,
         include_lookups: bool = True,
-        include_calls: bool = True,
+        include_calls: bool | Literal["descend_args"] = True,
         include_cses: bool = False,
         composite_leaves: bool | None = None,
-    ):
+    ) -> None:
         """
         :arg composite_leaves: Setting this is equivalent to setting
             all preceding ``include_*`` flags.
@@ -66,6 +66,7 @@ class DependencyMapper(
             include_subscripts = False
             include_lookups = False
             include_calls = False
+
         if composite_leaves is True:
             include_subscripts = True
             include_lookups = True
@@ -76,7 +77,6 @@ class DependencyMapper(
         self.include_subscripts = include_subscripts
         self.include_lookups = include_lookups
         self.include_calls = include_calls
-
         self.include_cses = include_cses
 
     def map_variable(
@@ -150,15 +150,16 @@ class DependencyMapper(
         return set()
 
 
-class CachedDependencyMapper(CachedMapper, DependencyMapper):
+class CachedDependencyMapper(CachedMapper[DependenciesT, P],
+                             DependencyMapper[P]):
     def __init__(
         self,
-        include_subscripts=True,
-        include_lookups=True,
-        include_calls=True,
-        include_cses=False,
-        composite_leaves=None,
-    ):
+        include_subscripts: bool = True,
+        include_lookups: bool = True,
+        include_calls: bool | Literal["descend_args"] = True,
+        include_cses: bool = False,
+        composite_leaves: bool | None = None,
+    ) -> None:
         CachedMapper.__init__(self)
         DependencyMapper.__init__(
             self,


### PR DESCRIPTION
This adds `include_calls: bool | Literal["descend_args"] = True` to `DependencyMapper` and a few other small typing fixes.

I think this also exposes a typing bug (the mypy CI should fail). I added missing type parameters to `CachedDependencyMapper` and it started complaining
```
pymbolic/interop/ast.py:467: error: Item "AlgebraicLeaf" of "AlgebraicLeaf | CommonSubexpression" has no attribute "name"  [union-attr]
pymbolic/interop/ast.py:467: error: Item "CommonSubexpression" of "AlgebraicLeaf | CommonSubexpression" has no attribute "name"  [union-attr]
```
from https://github.com/inducer/pymbolic/blob/670bbbb188d1b65a64811d401f1c3f71e99f85f6/pymbolic/interop/ast.py#L465=L466. From what I can tell, that can return things that don't have a `.name` attribute, so not sure what the correct types would be. Suggestions?