### PR TITLE
Rename type aliases for consistency

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,9 +28,17 @@ intersphinx_mapping = {
         ("https://immutabledict.corenting.fr/", None)
 }
 autodoc_type_aliases = {
-    "ExpressionT": "ExpressionT",
-    "ArithmeticExpressionT": "ArithmeticExpressionT",
+    "Expression": "Expression",
+    "ArithmeticExpression": "ArithmeticExpression",
 }
+
+
+nitpick_ignore_regex = [
+    # Avoids this error. Not sure where to even look.
+    # <unknown>:1: WARNING: py:class reference target not found: ExpressionNode [ref.class]  # noqa: E501
+    ["py:class", r"ExpressionNode"],
+    ]
+
 
 import sys
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -69,10 +69,11 @@ You can also easily define your own objects to use inside an expression:
 
 .. doctest::
 
-    >>> from pymbolic.primitives import Expression, expr_dataclass
+    >>> from pymbolic import ExpressionNode, expr_dataclass
+    >>> from pymbolic.typing import Expression
     >>>
     >>> @expr_dataclass()
-    ... class FancyOperator(Expression):
+    ... class FancyOperator(ExpressionNode):
     ...     operand: Expression
     ...
     >>> u

--- a/doc/utilities.rst
+++ b/doc/utilities.rst
@@ -8,7 +8,8 @@ Parser
 
 .. function:: parse(expr_str)
 
-    Return a :class:`pymbolic.primitives.Expression` tree corresponding to *expr_str*.
+    Return a :class:`pymbolic.primitives.ExpressionNode` tree corresponding
+    to *expr_str*.
 
 The parser is also relatively easy to extend. See the source code of the following
 class.

--- a/pymbolic/__init__.py
+++ b/pymbolic/__init__.py
@@ -24,54 +24,60 @@ THE SOFTWARE.
 """
 
 
-from pymbolic.version import VERSION_TEXT as __version__  # noqa
+from functools import partial
 
-from . import parser
-from . import compiler
+from pytools import module_getattr_for_deprecations
 
-from .mapper import evaluator
-from .mapper import stringifier
-from .mapper import dependency
-from .mapper import substitutor
-from .mapper import differentiator
-from .mapper import distributor
-from .mapper import flattener
-from . import primitives
-
-from .primitives import (Variable as var,  # noqa: N813
+from . import compiler, parser, primitives
+from .compiler import compile
+from .mapper import (
+    dependency,
+    differentiator,
+    distributor,
+    evaluator,
+    flattener,
+    stringifier,
+    substitutor,
+)
+from .mapper.differentiator import differentiate, differentiate as diff
+from .mapper.distributor import distribute, distribute as expand
+from .mapper.evaluator import evaluate, evaluate_kw
+from .mapper.flattener import flatten
+from .mapper.substitutor import substitute
+from .parser import parse
+from .primitives import (  # noqa: N813
+    ExpressionNode,
     Variable,
-    Expression,
-    variables,
-    flattened_sum,
-    subscript,
+    Variable as var,
+    disable_subscript_by_getitem,
+    expr_dataclass,
     flattened_product,
-    quotient,
+    flattened_sum,
     linear_combination,
     make_common_subexpression as cse,
     make_sym_vector,
-    disable_subscript_by_getitem,
-    expr_dataclass,
+    quotient,
+    subscript,
+    variables,
 )
-from .parser import parse
-from .mapper.evaluator import evaluate
-from .mapper.evaluator import evaluate_kw
-from .compiler import compile
-from .mapper.substitutor import substitute
-from .mapper.differentiator import differentiate as diff
-from .mapper.differentiator import differentiate
-from .mapper.distributor import distribute as expand
-from .mapper.distributor import distribute
-from .mapper.flattener import flatten
-from .typing import NumberT, ScalarT, ArithmeticExpressionT, ExpressionT, BoolT
+from .typing import (
+    ArithmeticExpression,
+    Bool,
+    Expression,
+    Expression as _TypingExpression,
+    Number,
+    Scalar,
+)
+from pymbolic.version import VERSION_TEXT as __version__  # noqa
 
 
 __all__ = (
-    "ArithmeticExpressionT",
-    "BoolT",
+    "ArithmeticExpression",
+    "Bool",
     "Expression",
-    "ExpressionT",
-    "NumberT",
-    "ScalarT",
+    "ExpressionNode",
+    "Number",
+    "Scalar",
     "Variable",
     "compile",
     "compiler",
@@ -105,3 +111,10 @@ __all__ = (
     "var",
     "variables",
 )
+
+__getattr__ = partial(module_getattr_for_deprecations, __name__, {
+        "ExpressionT": ("pymbolic.typing.Expression", _TypingExpression, 2026),
+        "ArithmeticExpressionT": ("ArithmeticExpression", ArithmeticExpression, 2026),
+        "BoolT": ("Bool", Bool, 2026),
+        "ScalarT": ("Scalar", Scalar, 2026),
+        })

--- a/pymbolic/cse.py
+++ b/pymbolic/cse.py
@@ -137,7 +137,7 @@ def tag_common_subexpressions(exprs):
     get_key = NormalizedKeyGetter()
     ucm = UseCountMapper(get_key)
 
-    if isinstance(exprs, prim.Expression):
+    if isinstance(exprs, prim.ExpressionNode):
         raise TypeError("exprs should be an iterable of expressions")
 
     for expr in exprs:

--- a/pymbolic/geometric_algebra/__init__.py
+++ b/pymbolic/geometric_algebra/__init__.py
@@ -33,7 +33,7 @@ import numpy as np
 from pytools import memoize, memoize_method
 
 from pymbolic.primitives import expr_dataclass, is_zero
-from pymbolic.typing import ArithmeticExpressionT, T
+from pymbolic.typing import ArithmeticExpression, T
 
 
 __doc__ = """
@@ -293,7 +293,7 @@ def get_euclidean_space(n: int) -> Space:
 # }}}
 
 
-CoeffT = TypeVar("CoeffT", bound=ArithmeticExpressionT)
+CoeffT = TypeVar("CoeffT", bound=ArithmeticExpression)
 
 
 # {{{ blade product weights
@@ -428,7 +428,7 @@ def _cast_to_mv(obj: Any, space: Space) -> MultiVector:
 class MultiVector(Generic[CoeffT]):
     r"""An immutable multivector type. Its implementation follows [DFM].
     It is pickleable, and not picky about what data is used as coefficients.
-    It supports :class:`pymbolic.primitives.Expression` objects of course,
+    It supports :class:`pymbolic.primitives.ExpressionNode` objects of course,
     but it can take just about any other scalar-ish coefficients.
 
     .. autoattribute:: data

--- a/pymbolic/geometric_algebra/mapper.py
+++ b/pymbolic/geometric_algebra/mapper.py
@@ -49,21 +49,23 @@ from pymbolic.mapper.stringifier import (
     PREC_NONE,
     StringifyMapper as StringifyMapperBase,
 )
-from pymbolic.primitives import Expression
+from pymbolic.primitives import ExpressionNode
 
 
 class IdentityMapper(IdentityMapperBase[P]):
     def map_nabla(
-            self, expr: prim.Nabla, *args: P.args, **kwargs: P.kwargs) -> Expression:
+                self, expr: prim.Nabla, *args: P.args, **kwargs: P.kwargs
+            ) -> ExpressionNode:
         return expr
 
     def map_nabla_component(self,
-            expr: prim.NablaComponent, *args: P.args, **kwargs: P.kwargs) -> Expression:
+                expr: prim.NablaComponent, *args: P.args, **kwargs: P.kwargs
+            ) -> ExpressionNode:
         return expr
 
     def map_derivative_source(self,
                 expr: prim.DerivativeSource, *args: P.args, **kwargs: P.kwargs
-            ) -> Expression:
+            ) -> ExpressionNode:
         operand = self.rec(expr.operand, *args, **kwargs)
         if operand is expr.operand:
             return expr

--- a/pymbolic/geometric_algebra/primitives.py
+++ b/pymbolic/geometric_algebra/primitives.py
@@ -29,8 +29,8 @@ THE SOFTWARE.
 from collections.abc import Hashable
 from typing import ClassVar
 
-from pymbolic.primitives import Expression, Variable, expr_dataclass
-from pymbolic.typing import ExpressionT
+from pymbolic.primitives import ExpressionNode, Variable, expr_dataclass
+from pymbolic.typing import Expression
 
 
 class MultiVectorVariable(Variable):
@@ -39,7 +39,7 @@ class MultiVectorVariable(Variable):
 
 # {{{ geometric calculus
 
-class _GeometricCalculusExpression(Expression):
+class _GeometricCalculusExpression(ExpressionNode):
     def stringifier(self):
         from pymbolic.geometric_algebra.mapper import StringifyMapper
         return StringifyMapper
@@ -58,7 +58,7 @@ class Nabla(_GeometricCalculusExpression):
 
 @expr_dataclass()
 class DerivativeSource(_GeometricCalculusExpression):
-    operand: ExpressionT
+    operand: Expression
     nabla_id: Hashable
 
 

--- a/pymbolic/interop/ast.py
+++ b/pymbolic/interop/ast.py
@@ -31,7 +31,7 @@ from typing import Any, ClassVar
 
 import pymbolic.primitives as p
 from pymbolic.mapper import CachedMapper
-from pymbolic.typing import ExpressionT
+from pymbolic.typing import Expression
 
 
 __doc__ = r'''
@@ -263,7 +263,7 @@ class PymbolicToASTMapper(CachedMapper[ast.expr, []]):
         return ast.Name(id=expr.name)
 
     def _map_multi_children_op(self,
-                               children: tuple[ExpressionT, ...],
+                               children: tuple[Expression, ...],
                                op_type: ast.operator) -> ast.expr:
         rec_children = [self.rec(child) for child in children]
         result = rec_children[-1]
@@ -435,7 +435,7 @@ def to_python_ast(expr) -> ast.expr:
     return PymbolicToASTMapper()(expr)
 
 
-def to_evaluatable_python_function(expr: ExpressionT,
+def to_evaluatable_python_function(expr: Expression,
                                    fn_name: str
                                    ) -> str:
     """

--- a/pymbolic/interop/matchpy/__init__.py
+++ b/pymbolic/interop/matchpy/__init__.py
@@ -57,13 +57,13 @@ from matchpy import (
 )
 
 import pymbolic.primitives as p
-from pymbolic.typing import ScalarT
+from pymbolic.typing import Scalar as PbScalar
 
 
 ExprT: TypeAlias = Expression
 ConstantT = TypeVar("ConstantT")
-ToMatchpyT = Callable[[p.Expression], ExprT]
-FromMatchpyT = Callable[[ExprT], p.Expression]
+ToMatchpyT = Callable[[p.ExpressionNode], ExprT]
+FromMatchpyT = Callable[[ExprT], p.ExpressionNode]
 
 
 _NOT_OPERAND_METADATA = {"not_an_operand": True}
@@ -95,7 +95,7 @@ class _Constant(BaseAtom, Generic[ConstantT]):
 
 
 @op_dataclass
-class Scalar(_Constant[ScalarT]):
+class Scalar(_Constant[PbScalar]):
     _mapper_method: str = "map_scalar"
 
 
@@ -360,11 +360,11 @@ def _get_operand_at_path(expr: PymbolicOp, path: tuple[int, ...]) -> PymbolicOp:
     return result
 
 
-def match(subject: p.Expression,
-          pattern: p.Expression,
+def match(subject: p.ExpressionNode,
+          pattern: p.ExpressionNode,
           to_matchpy_expr: ToMatchpyT | None = None,
           from_matchpy_expr: FromMatchpyT | None = None
-          ) -> Iterator[Mapping[str, p.Expression | ScalarT]]:
+          ) -> Iterator[Mapping[str, p.ExpressionNode | PbScalar]]:
     from matchpy import Pattern, match
 
     from .tofrom import FromMatchpyExpressionMapper, ToMatchpyExpressionMapper
@@ -383,12 +383,12 @@ def match(subject: p.Expression,
                for name, expr in subst.items()}
 
 
-def match_anywhere(subject: p.Expression,
-                   pattern: p.Expression,
+def match_anywhere(subject: p.ExpressionNode,
+                   pattern: p.ExpressionNode,
                    to_matchpy_expr: ToMatchpyT | None = None,
                    from_matchpy_expr: FromMatchpyT | None = None
-                   ) -> Iterator[tuple[Mapping[str, p.Expression | ScalarT],
-                                       p.Expression | ScalarT]
+                   ) -> Iterator[tuple[Mapping[str, p.ExpressionNode | PbScalar],
+                                       p.ExpressionNode | PbScalar]
                                  ]:
     from matchpy import Pattern, match_anywhere
 
@@ -409,8 +409,8 @@ def match_anywhere(subject: p.Expression,
                from_matchpy_expr(_get_operand_at_path(m_subject, path)))
 
 
-def make_replacement_rule(pattern: p.Expression,
-                          replacement: Callable[..., p.Expression],
+def make_replacement_rule(pattern: p.ExpressionNode,
+                          replacement: Callable[..., p.ExpressionNode],
                           to_matchpy_expr: ToMatchpyT | None = None,
                           from_matchpy_expr: FromMatchpyT | None = None
                           ) -> ReplacementRule:
@@ -437,11 +437,11 @@ def make_replacement_rule(pattern: p.Expression,
                                                         from_matchpy_expr))
 
 
-def replace_all(expression: p.Expression,
+def replace_all(expression: p.ExpressionNode,
                 rules: Iterable[ReplacementRule],
                 to_matchpy_expr: ToMatchpyT | None = None,
                 from_matchpy_expr: FromMatchpyT | None = None
-                ) -> p.Expression | tuple[p.Expression, ...]:
+                ) -> p.ExpressionNode | tuple[p.ExpressionNode, ...]:
     import collections.abc as abc
 
     from matchpy import replace_all

--- a/pymbolic/interop/matchpy/tofrom.py
+++ b/pymbolic/interop/matchpy/tofrom.py
@@ -12,6 +12,7 @@ import pymbolic.interop.matchpy as m
 import pymbolic.primitives as p
 from pymbolic.interop.matchpy.mapper import Mapper as BaseMatchPyMapper
 from pymbolic.mapper import Mapper as BasePymMapper
+from pymbolic.typing import Scalar as PbScalar
 
 
 # {{{ to matchpy
@@ -117,7 +118,7 @@ class ToMatchpyExpressionMapper(BasePymMapper):
 # {{{ from matchpy
 
 class FromMatchpyExpressionMapper(BaseMatchPyMapper):
-    def map_scalar(self, expr: m.Scalar) -> m.ScalarT:
+    def map_scalar(self, expr: m.Scalar) -> PbScalar:
         return expr.value
 
     def map_variable(self, expr: m.Variable) -> p.Variable:
@@ -200,7 +201,7 @@ class FromMatchpyExpressionMapper(BaseMatchPyMapper):
 
 @dataclass(frozen=True, eq=True)
 class ToFromReplacement:
-    f: Callable[..., p.Expression]
+    f: Callable[..., p.ExpressionNode]
     to_matchpy_expr: m.ToMatchpyT
     from_matchpy_expr: m.FromMatchpyT
 

--- a/pymbolic/mapper/coefficient.py
+++ b/pymbolic/mapper/coefficient.py
@@ -28,10 +28,10 @@ from typing import Literal, TypeAlias, cast
 
 import pymbolic.primitives as p
 from pymbolic.mapper import Mapper
-from pymbolic.typing import ArithmeticExpressionT
+from pymbolic.typing import ArithmeticExpression
 
 
-CoeffsT: TypeAlias = Mapping[p.AlgebraicLeaf | Literal[1], ArithmeticExpressionT]
+CoeffsT: TypeAlias = Mapping[p.AlgebraicLeaf | Literal[1], ArithmeticExpression]
 
 
 class CoefficientCollector(Mapper[CoeffsT, []]):
@@ -41,7 +41,7 @@ class CoefficientCollector(Mapper[CoeffsT, []]):
     def map_sum(self, expr: p.Sum) -> CoeffsT:
         stride_dicts = [self.rec(ch) for ch in expr.children]
 
-        result: dict[p.AlgebraicLeaf | Literal[1], ArithmeticExpressionT] = {}
+        result: dict[p.AlgebraicLeaf | Literal[1], ArithmeticExpression] = {}
         for stride_dict in stride_dicts:
             for var, stride in stride_dict.items():
                 if var in result:
@@ -64,11 +64,11 @@ class CoefficientCollector(Mapper[CoeffsT, []]):
                                 "nonlinear expression")
                     idx_of_child_with_vars = i
 
-        other_coeffs: ArithmeticExpressionT = 1
+        other_coeffs: ArithmeticExpression = 1
         for i, child_coeffs in enumerate(children_coeffs):
             if i != idx_of_child_with_vars:
                 assert len(child_coeffs) == 1
-                other_coeffs *= cast(ArithmeticExpressionT, child_coeffs[1])
+                other_coeffs *= cast(ArithmeticExpression, child_coeffs[1])
 
         if idx_of_child_with_vars is None:
             return {1: other_coeffs}

--- a/pymbolic/mapper/constant_folder.py
+++ b/pymbolic/mapper/constant_folder.py
@@ -35,10 +35,10 @@ from pymbolic.mapper import (
     Mapper,
 )
 from pymbolic.primitives import Product, Sum, is_arithmetic_expression
-from pymbolic.typing import ArithmeticExpressionT, ExpressionT
+from pymbolic.typing import ArithmeticExpression, Expression
 
 
-class ConstantFoldingMapperBase(Mapper[ExpressionT, []]):
+class ConstantFoldingMapperBase(Mapper[Expression, []]):
     def is_constant(self, expr):
         from pymbolic.mapper.dependency import DependencyMapper
         return not bool(DependencyMapper()(expr))
@@ -53,16 +53,16 @@ class ConstantFoldingMapperBase(Mapper[ExpressionT, []]):
     def fold(self,
              expr: Sum | Product,
              op: Callable[
-                 [ArithmeticExpressionT, ArithmeticExpressionT],
-                 ArithmeticExpressionT],
+                 [ArithmeticExpression, ArithmeticExpression],
+                 ArithmeticExpression],
              constructor: Callable[
-                     [tuple[ArithmeticExpressionT, ...]],
-                     ArithmeticExpressionT],
-         ) -> ExpressionT:
+                     [tuple[ArithmeticExpression, ...]],
+                     ArithmeticExpression],
+         ) -> Expression:
         klass = type(expr)
 
-        constants: list[ArithmeticExpressionT] = []
-        nonconstants: list[ArithmeticExpressionT] = []
+        constants: list[ArithmeticExpression] = []
+        nonconstants: list[ArithmeticExpression] = []
 
         queue = list(expr.children)
         while queue:
@@ -90,7 +90,7 @@ class ConstantFoldingMapperBase(Mapper[ExpressionT, []]):
         else:
             return constructor(tuple(nonconstants))
 
-    def map_sum(self, expr: Sum) -> ExpressionT:
+    def map_sum(self, expr: Sum) -> Expression:
         import operator
 
         from pymbolic.primitives import flattened_sum
@@ -108,7 +108,7 @@ class CommutativeConstantFoldingMapperBase(ConstantFoldingMapperBase):
 
 
 class ConstantFoldingMapper(
-        CSECachingMapperMixin[ExpressionT, []],
+        CSECachingMapperMixin[Expression, []],
         ConstantFoldingMapperBase,
         IdentityMapper[[]]):
 
@@ -117,7 +117,7 @@ class ConstantFoldingMapper(
 
 
 class CommutativeConstantFoldingMapper(
-        CSECachingMapperMixin[ExpressionT, []],
+        CSECachingMapperMixin[Expression, []],
         CommutativeConstantFoldingMapperBase,
         IdentityMapper[[]]):
 

--- a/pymbolic/mapper/distributor.py
+++ b/pymbolic/mapper/distributor.py
@@ -34,7 +34,7 @@ import pymbolic.primitives as p
 from pymbolic.mapper import IdentityMapper
 from pymbolic.mapper.collector import TermCollector
 from pymbolic.mapper.constant_folder import CommutativeConstantFoldingMapper
-from pymbolic.typing import ArithmeticExpressionT, ExpressionT
+from pymbolic.typing import ArithmeticExpression, Expression
 
 
 class DistributeMapper(IdentityMapper[[]]):
@@ -69,7 +69,7 @@ class DistributeMapper(IdentityMapper[[]]):
         else:
             return res
 
-    def map_product(self, expr: p.Product) -> ExpressionT:
+    def map_product(self, expr: p.Product) -> Expression:
         def dist(prod):
             if not isinstance(prod, p.Product):
                 return prod
@@ -112,13 +112,13 @@ class DistributeMapper(IdentityMapper[[]]):
                     self.rec(expr.numerator)
                     ])
 
-    def map_power(self, expr: p.Power) -> ExpressionT:
+    def map_power(self, expr: p.Power) -> Expression:
         from pymbolic.primitives import Sum
 
         newbase = self.rec(expr.base)
         if isinstance(newbase, p.Product):
             return self.rec(pymbolic.flattened_product([
-                cast(ArithmeticExpressionT, child)**expr.exponent
+                cast(ArithmeticExpression, child)**expr.exponent
                     for child in newbase.children
                 ]))
 
@@ -133,7 +133,9 @@ class DistributeMapper(IdentityMapper[[]]):
             return IdentityMapper.map_power(self, expr)
 
 
-def distribute(expr: ExpressionT, parameters=None, commutative=True) -> ExpressionT:
+def distribute(
+            expr: Expression, parameters=None, commutative=True
+        ) -> Expression:
     if parameters is None:
         parameters = frozenset()
     if commutative:

--- a/pymbolic/mapper/evaluator.py
+++ b/pymbolic/mapper/evaluator.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, cast
 
 import pymbolic.primitives as p
 from pymbolic.mapper import CachedMapper, CSECachingMapperMixin, Mapper, ResultT
-from pymbolic.typing import ExpressionT
+from pymbolic.typing import Expression
 
 
 if TYPE_CHECKING:
@@ -155,7 +155,7 @@ class EvaluationMapper(Mapper[ResultT, []], CSECachingMapperMixin):
     def map_logical_and(self, expr: p.LogicalAnd) -> bool:  # type: ignore[override]
         return all(self.rec(ch) for ch in expr.children)
 
-    def map_list(self, expr: list[ExpressionT]) -> ResultT:
+    def map_list(self, expr: list[Expression]) -> ResultT:
         return [self.rec(child) for child in expr]  # type: ignore[return-value]
 
     def map_numpy_array(self, expr: np.ndarray) -> ResultT:
@@ -188,7 +188,7 @@ class EvaluationMapper(Mapper[ResultT, []], CSECachingMapperMixin):
     def map_max(self, expr: p.Max) -> ResultT:
         return max(self.rec(child) for child in expr.children)  # type: ignore[type-var]
 
-    def map_tuple(self, expr: tuple[ExpressionT, ...]) -> ResultT:
+    def map_tuple(self, expr: tuple[Expression, ...]) -> ResultT:
         return tuple([self.rec(child) for child in expr])  # type: ignore[return-value]
 
     def map_nan(self, expr: p.NaN) -> ResultT:
@@ -222,7 +222,7 @@ class CachedFloatEvaluationMapper(CachedEvaluationMapper[float]):
 
 
 def evaluate(
-            expression: ExpressionT,
+            expression: Expression,
             context: Mapping[str, ResultT] | None = None,
             mapper_cls: type[EvaluationMapper[ResultT]] = CachedEvaluationMapper,
         ) -> ResultT:
@@ -236,7 +236,7 @@ def evaluate(
 
 
 def evaluate_kw(
-            expression: ExpressionT,
+            expression: Expression,
             mapper_cls: type[EvaluationMapper[ResultT]] = CachedEvaluationMapper,
             **context: ResultT,
         ) -> ResultT:

--- a/pymbolic/mapper/flattener.py
+++ b/pymbolic/mapper/flattener.py
@@ -35,7 +35,11 @@ from typing import cast
 
 import pymbolic.primitives as p
 from pymbolic.mapper import IdentityMapper
-from pymbolic.typing import ArithmeticExpressionT, ArithmeticOrExpressionT, ExpressionT
+from pymbolic.typing import (
+    ArithmeticExpression,
+    ArithmeticOrExpressionT,
+    Expression,
+)
 
 
 class FlattenMapper(IdentityMapper[[]]):
@@ -52,7 +56,7 @@ class FlattenMapper(IdentityMapper[[]]):
     .. automethod:: is_expr_integer_valued
     """
 
-    def is_expr_integer_valued(self, expr: ExpressionT) -> bool:
+    def is_expr_integer_valued(self, expr: Expression) -> bool:
         """A user-supplied method to indicate whether a given *expr* is integer-
         valued. This enables additional simplifications that are not valid in
         general. The default implementation simply returns *False*.
@@ -61,19 +65,19 @@ class FlattenMapper(IdentityMapper[[]]):
         """
         return False
 
-    def map_sum(self, expr: p.Sum) -> ExpressionT:
+    def map_sum(self, expr: p.Sum) -> Expression:
         from pymbolic.primitives import flattened_sum
         return flattened_sum([
-                             cast(ArithmeticExpressionT, self.rec(ch))
+                             cast(ArithmeticExpression, self.rec(ch))
                              for ch in expr.children])
 
-    def map_product(self, expr: p.Product) -> ExpressionT:
+    def map_product(self, expr: p.Product) -> Expression:
         from pymbolic.primitives import flattened_product
         return flattened_product([
-                                 cast(ArithmeticExpressionT, self.rec(ch))
+                                 cast(ArithmeticExpression, self.rec(ch))
                                  for ch in expr.children])
 
-    def map_quotient(self, expr: p.Quotient) -> ExpressionT:
+    def map_quotient(self, expr: p.Quotient) -> Expression:
         r_num = self.rec_arith(expr.numerator)
         r_den = self.rec_arith(expr.denominator)
         if p.is_zero(r_num):
@@ -83,7 +87,7 @@ class FlattenMapper(IdentityMapper[[]]):
 
         return expr.__class__(r_num, r_den)
 
-    def map_floor_div(self, expr: p.FloorDiv) -> ExpressionT:
+    def map_floor_div(self, expr: p.FloorDiv) -> Expression:
         r_num = self.rec_arith(expr.numerator)
         r_den = self.rec_arith(expr.denominator)
         if p.is_zero(r_num):
@@ -95,7 +99,7 @@ class FlattenMapper(IdentityMapper[[]]):
 
         return expr.__class__(r_num, r_den)
 
-    def map_remainder(self, expr: p.Remainder) -> ExpressionT:
+    def map_remainder(self, expr: p.Remainder) -> Expression:
         r_num = self.rec_arith(expr.numerator)
         r_den = self.rec_arith(expr.denominator)
         assert p.is_arithmetic_expression(r_den)
@@ -108,7 +112,7 @@ class FlattenMapper(IdentityMapper[[]]):
 
         return expr.__class__(r_num, r_den)
 
-    def map_power(self, expr: p.Power) -> ExpressionT:
+    def map_power(self, expr: p.Power) -> Expression:
         r_base = self.rec_arith(expr.base)
         r_exp = self.rec_arith(expr.exponent)
 

--- a/pymbolic/mapper/stringifier.py
+++ b/pymbolic/mapper/stringifier.py
@@ -30,7 +30,7 @@ from typing_extensions import deprecated
 
 import pymbolic.primitives as p
 from pymbolic.mapper import CachedMapper, Mapper, P
-from pymbolic.typing import ExpressionT
+from pymbolic.typing import Expression
 
 
 if TYPE_CHECKING:
@@ -95,11 +95,11 @@ PREC_NONE = 0
 class StringifyMapper(Mapper[str, Concatenate[int, P]]):
     """A mapper to turn an expression tree into a string.
 
-    :class:`pymbolic.Expression.__str__` is often implemented using
+    :class:`pymbolic.ExpressionNode.__str__` is often implemented using
     this mapper.
 
-    When it encounters an unsupported :class:`pymbolic.Expression`
-    subclass, it calls its :meth:`pymbolic.Expression.make_stringifier`
+    When it encounters an unsupported :class:`pymbolic.ExpressionNode`
+    subclass, it calls its :meth:`pymbolic.ExpressionNode.make_stringifier`
     method to get a :class:`StringifyMapper` that potentially does.
     """
 
@@ -108,7 +108,7 @@ class StringifyMapper(Mapper[str, Concatenate[int, P]]):
     def format(self, s: str, *args: object) -> str:
         return s % args
 
-    def join(self, joiner: str, seq: Sequence[ExpressionT]) -> str:
+    def join(self, joiner: str, seq: Sequence[Expression]) -> str:
         return self.format(joiner.join("%s" for _ in seq), *seq)
 
     # {{{ deprecated junk
@@ -136,7 +136,7 @@ class StringifyMapper(Mapper[str, Concatenate[int, P]]):
     def join_rec(
         self,
         joiner: str,
-        seq: Sequence[ExpressionT],
+        seq: Sequence[Expression],
         prec: int,
         *args,
         **kwargs,  # force_with_parens_around may hide in here
@@ -167,7 +167,7 @@ class StringifyMapper(Mapper[str, Concatenate[int, P]]):
 
     def rec_with_parens_around_types(
         self,
-        expr: ExpressionT,
+        expr: Expression,
         enclosing_prec: int,
         parens_around: tuple[type, ...],
         *args: P.args,
@@ -183,7 +183,7 @@ class StringifyMapper(Mapper[str, Concatenate[int, P]]):
     def join_rec_with_parens_around_types(
         self,
         joiner: str,
-        seq: Sequence[ExpressionT],
+        seq: Sequence[Expression],
         prec: int,
         parens_around_types: tuple[type, ...],
         *args: P.args,
@@ -565,7 +565,7 @@ class StringifyMapper(Mapper[str, Concatenate[int, P]]):
 
     def map_list(
         self,
-        expr: list[ExpressionT],
+        expr: list[Expression],
         enclosing_prec: int,
         *args: P.args,
         **kwargs: P.kwargs,
@@ -578,7 +578,7 @@ class StringifyMapper(Mapper[str, Concatenate[int, P]]):
 
     def map_tuple(
         self,
-        expr: tuple[ExpressionT, ...],
+        expr: tuple[Expression, ...],
         enclosing_prec: int,
         *args: P.args,
         **kwargs: P.kwargs,
@@ -773,7 +773,7 @@ class CSESplittingStringifyMapperMixin(Mapper[str, Concatenate[int, P]]):
     of the use of this mix-in.
     """
 
-    cse_to_name: dict[ExpressionT, str]
+    cse_to_name: dict[Expression, str]
     cse_names: set[str]
     cse_name_list: list[tuple[str, str]]
 

--- a/pymbolic/mapper/substitutor.py
+++ b/pymbolic/mapper/substitutor.py
@@ -4,7 +4,7 @@
 .. autofunction:: make_subst_func
 .. autofunction:: substitute
 
-.. autoclass:: Callable[[AlgebraicLeaf], ExpressionT | None]
+.. autoclass:: Callable[[AlgebraicLeaf], Expression | None]
 
 References
 ----------
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING, Any
 
 from pymbolic.mapper import CachedIdentityMapper, IdentityMapper
 from pymbolic.primitives import AlgebraicLeaf
-from pymbolic.typing import ExpressionT
+from pymbolic.typing import Expression
 
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
 class SubstitutionMapper(IdentityMapper[[]]):
     def __init__(
-        self, subst_func: Callable[[AlgebraicLeaf], ExpressionT | None]
+        self, subst_func: Callable[[AlgebraicLeaf], Expression | None]
     ) -> None:
         self.subst_func = subst_func
 
@@ -80,7 +80,7 @@ class SubstitutionMapper(IdentityMapper[[]]):
 
 class CachedSubstitutionMapper(CachedIdentityMapper[[]], SubstitutionMapper):
     def __init__(
-        self, subst_func: Callable[[AlgebraicLeaf], ExpressionT | None]
+        self, subst_func: Callable[[AlgebraicLeaf], Expression | None]
     ) -> None:
         # FIXME Mypy says:
         # error: Argument 1 to "__init__" of "CachedMapper" has incompatible type
@@ -93,11 +93,11 @@ class CachedSubstitutionMapper(CachedIdentityMapper[[]], SubstitutionMapper):
 def make_subst_func(
     # "Any" here avoids the whole Mapping variance disaster
     # e.g. https://github.com/python/typing/issues/445
-    variable_assignments: SupportsGetItem[Any, ExpressionT],
-) -> Callable[[AlgebraicLeaf], ExpressionT | None]:
+    variable_assignments: SupportsGetItem[Any, Expression],
+) -> Callable[[AlgebraicLeaf], Expression | None]:
     import pymbolic.primitives as primitives
 
-    def subst_func(var: AlgebraicLeaf) -> ExpressionT | None:
+    def subst_func(var: AlgebraicLeaf) -> Expression | None:
         try:
             return variable_assignments[var]
         except KeyError:
@@ -113,10 +113,11 @@ def make_subst_func(
 
 
 def substitute(
-    expression: ExpressionT,
-    variable_assignments: SupportsItems[AlgebraicLeaf | str, ExpressionT] | None = None,
+    expression: Expression,
+    variable_assignments: SupportsItems[AlgebraicLeaf | str, Expression] | None
+    = None,
     mapper_cls=CachedSubstitutionMapper,
-    **kwargs: ExpressionT,
+    **kwargs: Expression,
 ):
     """
     :arg mapper_cls: A :class:`type` of the substitution mapper
@@ -125,7 +126,7 @@ def substitute(
     if variable_assignments is None:
         # "Any" here avoids pointless grief about variance
         # e.g. https://github.com/python/typing/issues/445
-        v_ass_copied: dict[Any, ExpressionT] = {}
+        v_ass_copied: dict[Any, Expression] = {}
     else:
         v_ass_copied = dict(variable_assignments.items())
 

--- a/pymbolic/parser.py
+++ b/pymbolic/parser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pymbolic.typing import ExpressionT
+from pymbolic.typing import Expression
 
 
 __copyright__ = "Copyright (C) 2009-2013 Andreas Kloeckner"
@@ -561,7 +561,7 @@ class Parser:
 
             comma_allowed = True
 
-    def __call__(self, expr_str: str, min_precedence: int = 0) -> ExpressionT:
+    def __call__(self, expr_str: str, min_precedence: int = 0) -> Expression:
         lex_result = [(tag, s, idx, match_obj)
                 for (tag, s, idx, match_obj) in pytools.lex.lex(
                     self.lex_table, expr_str,

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -2055,7 +2055,7 @@ def make_sym_array(name, shape, var_factory=Variable):
     import numpy as np
     result = np.zeros(shape, dtype=object)
     for i in np.ndindex(shape):
-        result[i] = vfld.index(i)
+        result[i] = vfld[i]
 
     return result
 

--- a/pymbolic/rational.py
+++ b/pymbolic/rational.py
@@ -29,7 +29,7 @@ import pymbolic.primitives as primitives
 import pymbolic.traits as traits
 
 
-class Rational(primitives.Expression):
+class Rational(primitives.ExpressionNode):
     def __init__(self, numerator, denominator=1):
         d_unit = traits.traits(denominator).get_unit(denominator)
         numerator /= d_unit
@@ -74,9 +74,9 @@ class Rational(primitives.Expression):
             gcd = t.gcd(newden, newnum)
             return primitives.quotient(newnum/gcd, newden/gcd)
         except traits.NoTraitsError:
-            return primitives.Expression.__add__(self, other)
+            return primitives.ExpressionNode.__add__(self, other)
         except traits.NoCommonTraitsError:
-            return primitives.Expression.__add__(self, other)
+            return primitives.ExpressionNode.__add__(self, other)
 
     __radd__ = __add__
 
@@ -106,9 +106,9 @@ class Rational(primitives.Expression):
 
             return Rational(new_num, new_denom)
         except traits.NoTraitsError:
-            return primitives.Expression.__mul__(self, other)
+            return primitives.ExpressionNode.__mul__(self, other)
         except traits.NoCommonTraitsError:
-            return primitives.Expression.__mul__(self, other)
+            return primitives.ExpressionNode.__mul__(self, other)
 
     __rmul__ = __mul__
 

--- a/pymbolic/typing.py
+++ b/pymbolic/typing.py
@@ -4,28 +4,61 @@
 Typing helpers
 --------------
 
-.. autoclass:: BoolT
-.. autoclass:: NumberT
-.. autoclass:: ScalarT
-.. autoclass:: ArithmeticExpressionT
+.. autoclass:: Bool
+.. autoclass:: Number
+.. autoclass:: Scalar
+.. autoclass:: ArithmeticExpression
 
-    A narrower type alias than :class:`ExpressionT` that is returned by
+    A narrower type alias than :class:`Expression` that is returned by
     arithmetic operators, to allow continue doing arithmetic with the result
     of arithmetic.
 
-.. autoclass:: ExpressionT
-
 .. currentmodule:: pymbolic.typing
+
+.. autoclass:: Expression
+
+.. note::
+
+    For backward compatibility, ``pymbolic.Expression``
+    will alias :class:`pymbolic.primitives.ExpressionNode` for now. Once its deprecation
+    period is up, it will be removed, and then, in the further future,
+    ``pymbolic.Expression`` may become this type alias.
 
 .. autoclass:: ArithmeticOrExpressionT
 
-    A type variable that can be either :data:`ArithmeticExpressionT`
-    or :data:`ExpressionT`.
+    A type variable that can be either :data:`ArithmeticExpression`
+    or :data:`Expression`.
 """
 
 from __future__ import annotations
 
+
+__copyright__ = "Copyright (C) 2024 University of Illinois Board of Trustees"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from functools import partial
 from typing import TYPE_CHECKING, TypeAlias, TypeVar, Union
+
+from pytools import module_getattr_for_deprecations
 
 
 # FIXME: This is a lie. Many more constant types (e.g. numpy and such)
@@ -45,7 +78,7 @@ from typing import TYPE_CHECKING, TypeAlias, TypeVar, Union
 # https://github.com/python/typeshed/blob/119cd09655dcb4ed7fb2021654ba809b8d88846f/stdlib/numbers.pyi
 
 if TYPE_CHECKING:
-    from pymbolic.primitives import Expression
+    from pymbolic.primitives import ExpressionNode
 
 # Experience with depending packages showed that including Decimal and Fraction
 # from the stdlib was more trouble than it's worth because those types don't cleanly
@@ -59,37 +92,46 @@ _StdlibInexactNumberT = float | complex
 if TYPE_CHECKING:
     # Yes, type-checking pymbolic will require numpy. That's OK.
     import numpy as np
-    BoolT = bool | np.bool_
-    IntegerT: TypeAlias = int | np.integer
-    InexactNumberT: TypeAlias = _StdlibInexactNumberT | np.inexact
+    Bool = bool | np.bool_
+    Integer: TypeAlias = int | np.integer
+    InexactNumber: TypeAlias = _StdlibInexactNumberT | np.inexact
 else:
     try:
         import numpy as np
     except ImportError:
-        BoolT = bool
-        IntegerT: TypeAlias = int
-        InexactNumberT: TypeAlias = _StdlibInexactNumberT
+        Bool = bool
+        Integer: TypeAlias = int
+        InexactNumber: TypeAlias = _StdlibInexactNumberT
     else:
-        BoolT = bool | np.bool_
-        IntegerT: TypeAlias = int | np.integer
-        InexactNumberT: TypeAlias = _StdlibInexactNumberT | np.inexact
+        Bool = bool | np.bool_
+        Integer: TypeAlias = int | np.integer
+        InexactNumber: TypeAlias = _StdlibInexactNumberT | np.inexact
 
 
-NumberT: TypeAlias = IntegerT | InexactNumberT
-ScalarT: TypeAlias = NumberT | BoolT
+Number: TypeAlias = Integer | InexactNumber
+Scalar: TypeAlias = Number | Bool
 
-_ScalarOrExpression = Union[ScalarT, "Expression"]
-ArithmeticExpressionT: TypeAlias = Union[NumberT, "Expression"]
+_ScalarOrExpression = Union[Scalar, "ExpressionNode"]
+ArithmeticExpression: TypeAlias = Union[Number, "ExpressionNode"]
 
-ExpressionT: TypeAlias = _ScalarOrExpression | tuple["ExpressionT", ...]
+Expression: TypeAlias = _ScalarOrExpression | tuple["Expression", ...]
 
 ArithmeticOrExpressionT = TypeVar(
                 "ArithmeticOrExpressionT",
-                ArithmeticExpressionT,
-                ExpressionT)
+                ArithmeticExpression,
+                Expression)
 
 
 T = TypeVar("T")
+
+
+__getattr__ = partial(module_getattr_for_deprecations, __name__, {
+        "ArithmeticExpressionT": ("ArithmeticExpression", ArithmeticExpression, 2026),
+        "ExpressionT": ("Expression", Expression, 2026),
+        "IntegerT": ("Integer", Integer, 2026),
+        "ScalarT": ("Scalar", Scalar, 2026),
+        "BoolT": ("Bool", Bool, 2026),
+        })
 
 
 def not_none(x: T | None) -> T:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "immutabledict",
-    "pytools>=2022.1.14",
+    "pytools>=2024.1.16",
     # for dataclass_transform, TypeAlias, deprecated
     "typing-extensions>=4.5",
     "useful-types",

--- a/test/test_pymbolic.py
+++ b/test/test_pymbolic.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pymbolic.mapper.evaluator import evaluate_kw
 from pymbolic.mapper.flattener import FlattenMapper
 from pymbolic.mapper.stringifier import StringifyMapper
-from pymbolic.typing import ExpressionT
+from pymbolic.typing import Expression
 
 
 __copyright__ = "Copyright (C) 2009-2013 Andreas Kloeckner"
@@ -567,7 +567,7 @@ def test_pickle():
         assert expr == pickled
 
 
-class OldTimeyExpression(prim.Expression):
+class OldTimeyExpression(prim.ExpressionNode):
     init_arg_names = ()
 
     def __getinitargs__(self):
@@ -921,7 +921,7 @@ class InCacheVerifier(WalkMapper):
         self.walk_call_functions = walk_call_functions
 
     def post_visit(self, expr):
-        if isinstance(expr, prim.Expression):
+        if isinstance(expr, prim.ExpressionNode):
             assert (self.cached_mapper.get_cache_key(expr)
                     in self.cached_mapper._cache)
 
@@ -1038,7 +1038,7 @@ def test_python_ast_interop_roundtrip():
 
 @prim.expr_dataclass()
 class CustomOperator:
-    child: ExpressionT
+    child: Expression
 
     def make_stringifier(self, originating_stringifier=None):
         return OperatorStringifier()
@@ -1058,7 +1058,7 @@ def test_derived_stringifier() -> None:
 # {{{ test_flatten
 
 class IntegerFlattenMapper(FlattenMapper):
-    def is_expr_integer_valued(self, expr: ExpressionT) -> bool:
+    def is_expr_integer_valued(self, expr: Expression) -> bool:
         return True
 
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -47,7 +47,7 @@ class RandomExpressionGeneratorContext:
 
 
 def _generate_random_expr_inner(
-        context: RandomExpressionGeneratorContext) -> prim.Expression:
+        context: RandomExpressionGeneratorContext) -> prim.ExpressionNode:
 
     if context.current_depth >= context.max_depth:
         # force expression to be a leaf type
@@ -92,7 +92,7 @@ def _generate_random_expr_inner(
         raise NotImplementedError(expr_type)
 
 
-def generate_random_expression(seed: int, max_depth: int = 8) -> prim.Expression:
+def generate_random_expression(seed: int, max_depth: int = 8) -> prim.ExpressionNode:
     from numpy.random import default_rng
     rng = default_rng(seed)
     vng = UniqueNameGenerator()


### PR DESCRIPTION
This was straightforward enough to make with pyright's symbol rename support. I'm not sure  I fully understand the compatibility implications.

- [x] Needs https://github.com/inducer/pytools/pull/268 and a pytools release