### PR TITLE
Fix fixed numpy typing warnings

### DIFF
--- a/pymbolic/mapper/__init__.py
+++ b/pymbolic/mapper/__init__.py
@@ -963,7 +963,7 @@ class IdentityMapper(Mapper[Expression, P]):
         import numpy
         result = numpy.empty(expr.shape, dtype=object)
         for i in numpy.ndindex(expr.shape):
-            result[i] = self.rec(expr[i], *args, **kwargs)  # type: ignore[assignment]
+            result[i] = self.rec(expr[i], *args, **kwargs)
 
         # True fact: ndarrays aren't expressions
         return result  # type: ignore[return-value]

--- a/pymbolic/mapper/evaluator.py
+++ b/pymbolic/mapper/evaluator.py
@@ -163,7 +163,7 @@ class EvaluationMapper(Mapper[ResultT, []], CSECachingMapperMixin):
         import numpy
         result = numpy.empty(expr.shape, dtype=object)
         for i in numpy.ndindex(expr.shape):
-            result[i] = self.rec(expr[i])  # type: ignore[call-overload]
+            result[i] = self.rec(expr[i])
         return result  # type: ignore[return-value]
 
     def map_multivector(self, expr: MultiVector) -> ResultT:

--- a/pymbolic/primitives.py
+++ b/pymbolic/primitives.py
@@ -648,8 +648,8 @@ class ExpressionNode:
             return Subscript(self, subscript.child)
 
         if subscript == ():
-            warn("Expression.__getitem__ called with an empty tuple as an index. "
-                 "This still returns just the aggregate (not a Subscript), "
+            warn(f"{type(self).__name__}.__getitem__ called with an empty tuple as "
+                 "an index. This still returns just the aggregate (not a Subscript), "
                  "but this behavior will change in 2026. To avoid this warning "
                  "(and return a Subscript unconditionally), wrap the subscript "
                  "in pymbolic.primitives.EmptyOK.", DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
Numpy now recommends basedpyright: https://github.com/numpy/numpy/releases/tag/v2.2.1, so it seems like this will be a bit of a mess for a while :(