### PR TITLE
Fix alias for _Expression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,12 @@ Pymbolic: Easy Expression Trees and Term Rewriting
 .. image:: https://gitlab.tiker.net/inducer/pymbolic/badges/main/pipeline.svg
     :alt: Gitlab Build Status
     :target: https://gitlab.tiker.net/inducer/pymbolic/commits/main
-.. image:: https://github.com/inducer/pymbolic/workflows/CI/badge.svg?branch=main&event=push
+.. image:: https://github.com/inducer/pymbolic/actions/workflows/ci.yml/badge.svg
     :alt: Github Build Status
-    :target: https://github.com/inducer/pymbolic/actions?query=branch%3Amain+workflow%3ACI+event%3Apush
-.. image:: https://badge.fury.io/py/pymbolic.png
+    :target: https://github.com/inducer/pymbolic/actions/workflows/ci.yml
+.. image:: https://badge.fury.io/py/pymbolic.svg
     :alt: Python Package Index Release Page
-    :target: https://pypi.org/project/pymbolic/
+    :target: https://pypi.org/project/pymbolic
 .. image:: https://zenodo.org/badge/2016193.svg
     :alt: Zenodo DOI for latest release
     :target: https://zenodo.org/badge/latestdoi/2016193

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ sphinxconfig_missing_reference_aliases = {
     "Expression": "data:pymbolic.typing.Expression",
     "p.AlgebraicLeaf": "class:pymbolic.primitives.AlgebraicLeaf",
     "ExpressionNode": "class:pymbolic.primitives.ExpressionNode",
-    "_Expression": "class:pymbolic.primitives.ExpressionNode",
+    "_Expression": "data:pymbolic.typing.Expression",
     "Lookup": "class:pymbolic.primitives.Lookup",
     "LogicalAnd": "class:pymbolic.primitives.LogicalAnd",
     "LogicalOr": "class:pymbolic.primitives.LogicalOr",


### PR DESCRIPTION
It was incorrectly aliased to `ExpressionNode` in #196.

Also worth noting that it still shows up as `_Expression` in the docs, even though the link is correct. That probably requires some more hacking in `sphinxconfig.py`.