### PR TITLE
Remove _BUILDING_SPHINX_DOCS variable

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -56,14 +56,6 @@
                     "endColumn": 70,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
             }
         ],
         "./experiments/traversal-benchmark.py": [
@@ -26551,6 +26543,14 @@
             }
         ],
         "./pymbolic/mapper/substitutor.py": [
+            {
+                "code": "reportUnsafeMultipleInheritance",
+                "range": {
+                    "startColumn": 6,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,9 +66,3 @@ sphinxconfig_missing_reference_aliases = {
 
 def setup(app):
     app.connect("missing-reference", process_autodoc_missing_reference)  # noqa: F821
-
-
-import sys
-
-
-sys._BUILDING_SPHINX_DOCS = True

--- a/pymbolic/algorithm.py
+++ b/pymbolic/algorithm.py
@@ -43,7 +43,6 @@ THE SOFTWARE.
 """
 
 import operator
-import sys
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast, overload
 from warnings import warn
 
@@ -53,10 +52,6 @@ from pytools import MovedFunctionDeprecationWrapper, memoize
 if TYPE_CHECKING:
     import numpy as np
     from numpy.typing import NDArray
-
-
-if getattr(sys, "_BUILDING_SPHINX_DOCS", None):
-    import numpy as np  # noqa: TC002
 
 
 # {{{ integer powers

--- a/pymbolic/mapper/substitutor.py
+++ b/pymbolic/mapper/substitutor.py
@@ -4,8 +4,6 @@
 .. autofunction:: make_subst_func
 .. autofunction:: substitute
 
-.. autoclass:: Callable[[AlgebraicLeaf], Expression | None]
-
 References
 ----------
 
@@ -38,8 +36,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
-import sys
-from dataclasses import dataclass
+
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
@@ -56,17 +53,14 @@ if TYPE_CHECKING:
     from pymbolic.typing import Expression
 
 
-if getattr(sys, "_BUILDING_SPHINX_DOCS", None):
-    from collections.abc import Callable  # noqa: TC003
-
-
-@dataclass
 class SubstitutionMapper(IdentityMapper[[]]):
-
     subst_func: Callable[[AlgebraicLeaf], Expression | None]
 
-    def __post_init__(self) -> None:
+    def __init__(
+            self, subst_func: Callable[[AlgebraicLeaf], Expression | None]
+        ) -> None:
         super().__init__()
+        self.subst_func = subst_func
 
     @override
     def map_variable(self, expr: Variable) -> Expression:


### PR DESCRIPTION
Is this still needed for downstreams? The docs seem to generate correctly without it.